### PR TITLE
docs: fix PATH tools description in architecture.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@
 - **`bash_profile`**: Main bash configuration loaded on shell startup
   - Sources all lib scripts via `lib/index.sh`
   - Sets up environment variables (DEVPATH, DOTFILES, GOPATH, etc.)
-  - Configures PATH for Homebrew, NVM, pyenv, rbenv, jenv, and other tools
+  - Configures PATH for Homebrew, mise, and other tools
   - Implements prompt customization with git branch detection
   - Auto-loads correct Node version from .nvmrc or .node-version files
 


### PR DESCRIPTION

◐ dotfiles-s0l [BUG] · Fix docs/architecture.md PATH tools description   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

docs/architecture.md line 16 states 'Configures PATH for Homebrew, NVM, pyenv, rbenv, jenv, and other tools' but bash_profile no longer configures PATH for NVM, pyenv, or rbenv. Only Homebrew, jenv, and mise remain. The description is outdated and misleading.



ACCEPTANCE CRITERIA

docs/architecture.md line 16 accurately describes the tools currently configured in bash_profile.