### PR TITLE
fix(bootstrap): remove duplicate Homebrew delta formulas

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -371,8 +371,7 @@ then
       tree-sitter-cli \
       fzf \
       tmux \
-      delta \
-
+      git-delta \
       gh \
       beads
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -372,7 +372,7 @@ then
       fzf \
       tmux \
       delta \
-      git-delta \
+
       gh \
       beads
 


### PR DESCRIPTION

◐ dotfiles-784 [BUG] · Fix bootstrap.sh duplicate Homebrew delta formulas   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

bootstrap.sh lines 374-375 list both 'delta' and 'git-delta'. In Homebrew, 'delta' is an alias for 'git-delta'. Installing both causes a conflict or redundant install. Only one should be kept.



ACCEPTANCE CRITERIA

bootstrap.sh installs only one of delta or git-delta, not both.