### PR TITLE
fix(bootstrap): add empty passphrase to ed25519 ssh-keygen

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -187,7 +187,7 @@ then
 fi
 if [ ! -f "$HOME/.ssh/id_ed25519" ]
 then
-  ssh-keygen -t ed25519 -C "tribou@users.noreply.github.com"
+  ssh-keygen -t ed25519 -C "tribou@users.noreply.github.com" -N ""
 fi
 ## If macOS
 if [[ "$OSTYPE" == "darwin"* ]] && ! grep -q "AddKeysToAgent" ~/.ssh/config


### PR DESCRIPTION

◐ dotfiles-9q7 [BUG] · Fix bootstrap.sh ed25519 SSH key unattended generation   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

bootstrap.sh line 190 runs 'ssh-keygen -t ed25519' without -N flag, making it interactive and halting unattended bootstrap runs. The RSA key on line 186 uses '-N ""' (empty passphrase) but the ed25519 key does not, creating an inconsistency.



ACCEPTANCE CRITERIA

bootstrap.sh generates ed25519 SSH key without prompting for passphrase, matching the RSA key behavior.