### PR TITLE
fix(bootstrap): use command -v instead of which for POSIX compliance

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -437,7 +437,7 @@ then
 
   # Golang tools — install after mise provisions Go
   GO_BIN_DIR="${GOBIN:-$GOPATH/bin}"
-  if [ -x "$(which go)" ] && [ ! -x "$GO_BIN_DIR/gopls" ]
+  if [ -x "$(command -v go)" ] && [ ! -x "$GO_BIN_DIR/gopls" ]
   then
     echo "Installing gopls"
     go install golang.org/x/tools/gopls@latest


### PR DESCRIPTION

◐ dotfiles-882 [BUG] · Fix bootstrap.sh POSIX compliance: which -> command -v   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

bootstrap.sh line 440 uses '[ -x "/home/tribou/.local/share/mise/installs/go/1.26.3/bin/go" ]' which is non-POSIX. Some which implementations print error messages to stdout even when the command is not found. The script already uses 'command -v' everywhere else for consistency.



ACCEPTANCE CRITERIA

bootstrap.sh line 440 uses command -v instead of which for POSIX compliance.