### PR TITLE
fix(bash_profile): make _dotfiles_debug_timing portable across macOS and Linux

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -10,10 +10,16 @@ function _dotfiles_debug_timing ()
 {
   if [ -n "$DEBUG_BASH_PROFILE" ]
   then
+    local _date_cmd="date"
+    if [ "$OS" = "Darwin" ] && command -v gdate >/dev/null 2>&1
+    then
+      _date_cmd="gdate"
+    fi
+
     local LAST_TIME="$DOTFILES_DEBUG_LAST_TIME"
-    local LAST_TIME_NANO=$(gdate -u -d "$LAST_TIME" +"%s%N")
-    local NOW=$(gdate -u +"%Y-%m-%dT%H:%M:%S.%NZ")
-    local NOW_NANO=$(gdate -u -d "$NOW" +"%s%N")
+    local LAST_TIME_NANO=$($_date_cmd -u -d "$LAST_TIME" +"%s%N")
+    local NOW=$($_date_cmd -u +"%Y-%m-%dT%H:%M:%S.%NZ")
+    local NOW_NANO=$($_date_cmd -u -d "$NOW" +"%s%N")
     local DIFF="0"
     local MSG="$NOW $1 +$DIFF"
 


### PR DESCRIPTION

◐ dotfiles-073 [BUG] · Fix bash_profile _dotfiles_debug_timing gdate portability   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

bash_profile lines 14-29 use 'gdate' for GNU date, which is macOS Homebrew-specific. On Linux, 'gdate' does not exist and 'date' is already GNU date. Enabling DEBUG_BASH_PROFILE=1 on Linux will cause the function to fail.



ACCEPTANCE CRITERIA

_dotfiles_debug_timing works correctly when DEBUG_BASH_PROFILE=1 on both macOS and Linux.