### PR TITLE
fix(replace): use portable sed -i syntax across BSD and GNU

### DIFF
--- a/lib/replace.sh
+++ b/lib/replace.sh
@@ -81,7 +81,7 @@ Examples:
     ':!*.pnp.*' \
     ':!pnpm-lock.yaml' \
     ':!package-lock.json' \
-    | xargs sed -i '' -e ''s/"$1"/"$2"/g''
+    | xargs sed -i.bak -e ''s/"$1"/"$2"/g'' && find . -name '*.bak' -delete
 }
 
 # "Write" complement to ripgrep (rg --replace)

--- a/lib/replace.sh
+++ b/lib/replace.sh
@@ -18,8 +18,8 @@ findfiles() {
   # Optional first arg
   if [ $# -eq 1 ]
   then
-    # Remove trailing slash if any
-    local search_dir=`echo "$1" | sed 's/\/$//'`
+    local search_dir
+    search_dir=$(echo "$1" | sed 's/\/$//')
   fi
 
   find "$search_dir" \
@@ -70,6 +70,11 @@ Examples:
     local search_dir="$3"
   fi
 
+  local sed_i=(-i)
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed_i=(-i "")
+  fi
+
   git grep --untracked -I -l "$1" -- \
     "$search_dir" \
     ':!build/**' \
@@ -81,7 +86,7 @@ Examples:
     ':!*.pnp.*' \
     ':!pnpm-lock.yaml' \
     ':!package-lock.json' \
-    | xargs sed -i.bak -e ''s/"$1"/"$2"/g'' && find . -name '*.bak' -delete
+    | xargs sed "${sed_i[@]}" -e ''s/"$1"/"$2"/g''
 }
 
 # "Write" complement to ripgrep (rg --replace)
@@ -136,9 +141,9 @@ Examples:
       if test -n "$currentFile"; then
         echo "$currentFile"
         (sed '$d' | sed '$d') <<< "$part" > "$currentFile"
-        local didChange='true'
+        didChange='true'
       fi
-      local currentFile="$(tail -n 1 <<< "$part")"
+      currentFile="$(tail -n 1 <<< "$part")"
     done
 
     if test -z "$didChange"; then

--- a/tests/replace.bats
+++ b/tests/replace.bats
@@ -1,0 +1,47 @@
+# tests/replace.bats
+
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+
+  # Create a temp git repo for replace tests
+  TEMP_REPO=$(mktemp -d)
+  git -C "$TEMP_REPO" init -q
+  git -C "$TEMP_REPO" config user.email "test@test.com"
+  git -C "$TEMP_REPO" config user.name "Test"
+}
+
+teardown() {
+  cd "$BATS_TEST_DIRNAME"
+  rm -rf "$TEMP_REPO"
+}
+
+@test "replace: replaces pattern in a git-tracked file and does not delete unrelated .bak files" {
+  cd "$TEMP_REPO"
+
+  # Create a file and track it
+  echo "hello world" > test.txt
+  git add test.txt
+  git commit -m "add test"
+
+  # Create an unrelated .bak file
+  echo "preserve me" > unrelated.bak
+  git add unrelated.bak
+  git commit -m "add unrelated bak"
+
+  # Source the replace script explicitly
+  . "$REPO_ROOT/lib/replace.sh"
+
+  # Perform replacement
+  run replace "world" "earth"
+  assert_success
+
+  # Verify the replacement succeeded
+  run cat test.txt
+  assert_output "hello earth"
+
+  # Verify that the unrelated .bak file was NOT deleted
+  [ -f unrelated.bak ]
+  run cat unrelated.bak
+  assert_output "preserve me"
+}


### PR DESCRIPTION

◐ dotfiles-503 [BUG] · Fix lib/replace.sh sed -i '' BSD vs GNU syntax   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

lib/replace.sh line 84 uses 'sed -i '' -e ...' which is BSD/macOS sed syntax. On GNU sed (Linux), '-i '' creates a backup file literally named '' instead of in-place editing. This is a serious cross-platform bug.



ACCEPTANCE CRITERIA

lib/replace.sh works correctly for in-place edits on both macOS and Linux.