### PR TITLE
fix(aliases): make ls, less, top, prettyjson cross-platform

### DIFF
--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -1089,6 +1089,8 @@ alias to='echo; echo; git tree-one'
 alias tone='echo; echo; git tree-one'
 if [[ "$OSTYPE" == "darwin"* ]]; then
   alias top='top -o cpu'
+else
+  alias top='top -o %CPU'
 fi
 alias tree='tree -I "bower_components|dist|node_modules|temp|tmp"'
 alias ts='echo; echo; git tree-short'

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -1036,7 +1036,7 @@ alias j='TZ=UTC yarn jest --watch'
 alias k='kubectl'
 alias kd='kubectl describe'
 alias kg='kubectl get pods,rc,svc,ing -o wide --show-labels'
-alias less='less -r'
+alias less='less -R'
 alias ll='ls -lah'
 llm() { local _d; _d=$(printf '%q' "$PWD"); sudo -u agent -i bash -c "cd $_d && exec bash -li"; }
 agent-grant() {
@@ -1046,7 +1046,11 @@ agent-grant() {
   [[ "$confirm" == [yY] ]] || { echo "Aborted."; return 1; }
   sudo bash "$dotfiles/agent/setup-user.sh" --grant "$target"
 }
-alias ls='ls -G'
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  alias ls='ls -G'
+else
+  alias ls='ls --color=auto'
+fi
 alias lt='ls -lath'
 alias md='merge develop'
 alias mm='merge main'
@@ -1060,7 +1064,7 @@ alias nr='npm-run'
 alias nrs='npm rm --save'
 alias nrsd='npm rm --save-dev'
 alias ntsc='npx tsc --noemit --watch --pretty'
-alias prettyjson='python -m json.tool'
+alias prettyjson='python3 -m json.tool'
 alias proxy-mini='ssh -D 8001 tbomini-remote'
 alias r='git remote -v'
 alias remote-mini='ssh -L 9000:localhost:5900 -L 35729:localhost:35729 -L 4200:localhost:4200 -L 3000:localhost:3000 -L 8090:localhost:8090 -L 8000:localhost:8000 tbomini-remote'
@@ -1083,7 +1087,9 @@ alias tms='tmux-small'
 alias tint='_dotfiles_git_log_branch_diff'
 alias to='echo; echo; git tree-one'
 alias tone='echo; echo; git tree-one'
-alias top='top -o cpu'
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  alias top='top -o cpu'
+fi
 alias tree='tree -I "bower_components|dist|node_modules|temp|tmp"'
 alias ts='echo; echo; git tree-short'
 alias unsetdotglob='shopt -u dotglob'


### PR DESCRIPTION

◐ dotfiles-xdh [BUG] · Fix cross-platform shell aliases: ls, less, top, prettyjson   [● P2 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

Multiple aliases break on Linux because they use macOS-specific syntax: 1) alias ls='ls -G' - on GNU ls, -G means --no-group (hides group column), not color. 2) alias less='less -r' - -r is deprecated, should be -R. 3) alias top='top -o cpu' - macOS-only syntax. 4) prettyjson='python -m json.tool' - should use python3.



ACCEPTANCE CRITERIA

All aliases in lib/commands.sh and bash_profile work correctly on both macOS and Linux.