### PR TITLE
fix(commands): use standard npm -g flag instead of deprecated --location=global

### DIFF
--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -540,7 +540,7 @@ function new-docker-generic ()
 function npm-install-global ()
 {
   echo "Installing global modules"
-  npm install --location=global \
+  npm install -g \
     eas-cli \
     eslint_d \
     editorconfig \


### PR DESCRIPTION

◐ dotfiles-zue [BUG] · Fix npm install --location=global deprecated flag   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: bug

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

lib/commands.sh line 543 uses 'npm install --location=global' which was introduced in npm 8.x as an alternative but is not well documented in current npm and may be removed. The standard flag is '-g' or '--global', which is what the script should use.



ACCEPTANCE CRITERIA

lib/commands.sh npm-install-global uses 'npm install -g' instead of '--location=global'.