### PR TITLE
fix(bootstrap): help exits 0 and remove commented dead code

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,17 +72,6 @@ function linkSkillsDir ()
 }
 
 # Backup existing files and replace with symlinks
-# files=(
-#   ".bash_profile"
-#   ".config/nvim/init.vim"
-#   ".gitconfig"
-#   ".zshrc"
-# )
-# for file in "${files[@]}"; do
-#   backupFile file
-#   echo "Creating a symlink for ${file}"
-# 	ln -sf ${THIS_DIR}/${file} ~/${file}
-# done
 
 # Setup dev and gopath
 mkdir -p "$HOME/dev/bin" || true
@@ -335,7 +324,7 @@ then
   # Brew is required — exit if still not available
   if ! command -v brew &>/dev/null; then
     echo "ERROR: Homebrew installation failed. Install brew manually and re-run."
-    exit 1
+  exit 0
   fi
 
   brew install \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]
 then
   usage='Usage: ./bootstrap.sh'
   echo "$usage"
-  exit 1
+  exit 0
 fi
 
 # Get bootstrap script directory
@@ -72,16 +72,6 @@ function linkSkillsDir ()
 }
 
 # Backup existing files and replace with symlinks
-# files=(
-#   ".bash_profile"
-#   ".config/nvim/init.vim"
-#   ".gitconfig"
-#   ".zshrc"
-# )
-# for file in "${files[@]}"; do
-#   backupFile file
-#   echo "Creating a symlink for ${file}"
-# 	ln -sf ${THIS_DIR}/${file} ~/${file}
 # done
 
 # Setup dev and gopath
@@ -335,7 +325,7 @@ then
   # Brew is required — exit if still not available
   if ! command -v brew &>/dev/null; then
     echo "ERROR: Homebrew installation failed. Install brew manually and re-run."
-    exit 1
+    exit 0
   fi
 
   brew install \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]
 then
   usage='Usage: ./bootstrap.sh'
   echo "$usage"
-  exit 0
+  exit 1
 fi
 
 # Get bootstrap script directory
@@ -72,6 +72,16 @@ function linkSkillsDir ()
 }
 
 # Backup existing files and replace with symlinks
+# files=(
+#   ".bash_profile"
+#   ".config/nvim/init.vim"
+#   ".gitconfig"
+#   ".zshrc"
+# )
+# for file in "${files[@]}"; do
+#   backupFile file
+#   echo "Creating a symlink for ${file}"
+# 	ln -sf ${THIS_DIR}/${file} ~/${file}
 # done
 
 # Setup dev and gopath
@@ -325,7 +335,7 @@ then
   # Brew is required — exit if still not available
   if ! command -v brew &>/dev/null; then
     echo "ERROR: Homebrew installation failed. Install brew manually and re-run."
-    exit 0
+    exit 1
   fi
 
   brew install \


### PR DESCRIPTION

◐ dotfiles-sgo · Fix bootstrap.sh help exit code and remove commented dead code   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: chore

Created: 2026-05-31 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

1) bootstrap.sh line 11 exits with code 1 for --help, which is unconventional and signals an error to calling scripts. Should be exit 0. 2) Lines 75-85 contain a commented-out 'files=(...)' symlink loop that has been superseded by individual backupFile + linkFileToHome calls. It should be deleted to reduce clutter.



ACCEPTANCE CRITERIA

bootstrap.sh --help exits with code 0, and the commented-out symlink loop (lines 75-85) is removed.