### PR TITLE
test: add bootstrap idempotency test

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -162,6 +162,7 @@ backupFile ".config/nvim/coc-settings.json"
 linkFileToHome "coc-settings.json" ".config/nvim/coc-settings.json"
 
 # Symlink helper scripts for SSH markdown preview
+mkdir -p ~/.local/bin
 linkFileToHome "scripts/dotfiles_remote_browser_open.sh" ".local/bin/dotfiles_remote_browser_open.sh"
 linkFileToHome "scripts/dotfiles_local_browser_helper.sh" ".local/bin/dotfiles_local_browser_helper.sh"
 
@@ -175,6 +176,7 @@ linkSkillsDir "$THIS_DIR/skills" "$HOME/.config/opencode/skills"
 linkSkillsDir "$THIS_DIR/skills" "$HOME/.gemini/config/skills"
 
 # setup API keys file
+mkdir -p "$HOME/.ssh"
 if [ ! -f "$HOME/.ssh/api_keys" ]
 then
   touch "$HOME/.ssh/api_keys"

--- a/tests/bootstrap_idempotency.bats
+++ b/tests/bootstrap_idempotency.bats
@@ -8,20 +8,72 @@ setup() {
   local tmp_home
   tmp_home=$(mktemp -d)
   
-  # Run bootstrap twice in a row with a temp HOME
-  HOME="$tmp_home" bash "$REPO_ROOT/bootstrap.sh" || true
-  HOME="$tmp_home" bash "$REPO_ROOT/bootstrap.sh" || true
-
-  # Check that no file has duplicate lines
-  local dupes=0
-  for f in "$tmp_home/.bash_profile" "$tmp_home/.zshrc" "$tmp_home/.gitconfig"; do
-    if [ -f "$f" ]; then
-      local d
-      d=$(sort "$f" | uniq -d | wc -l)
-      dupes=$((dupes + d))
-    fi
+  # Create mock bin directory for external dependencies
+  local mock_bin="$tmp_home/mock_bin"
+  mkdir -p "$mock_bin"
+  
+  # Create basic mock commands that exit 0
+  for cmd in brew curl gpgconf gpg-agent tic tmux ssh-keygen ssh-add mise corepack npm pip3 gem go bd apt-get pacman sudo nvim; do
+    echo '#!/bin/sh' > "$mock_bin/$cmd"
+    echo 'exit 0' >> "$mock_bin/$cmd"
+    chmod +x "$mock_bin/$cmd"
   done
-
+  
+  # Custom mock for ssh-agent
+  echo '#!/bin/sh' > "$mock_bin/ssh-agent"
+  echo 'echo "SSH_AUTH_SOCK=/tmp/ssh-mock; export SSH_AUTH_SOCK; SSH_AGENT_PID=12345; export SSH_AGENT_PID;"' >> "$mock_bin/ssh-agent"
+  chmod +x "$mock_bin/ssh-agent"
+  
+  # Custom mock for git to handle directory setup for z and tpm
+  cat << 'EOF' > "$mock_bin/git"
+#!/bin/sh
+if [ "$1" = "clone" ]; then
+  # Create target file for z.sh so sourcing doesn't fail
+  mkdir -p "$HOME/dev/z"
+  touch "$HOME/dev/z/z.sh"
+  
+  # Create mock install_plugins for tpm
+  mkdir -p "$HOME/.tmux/plugins/tpm/bin"
+  echo '#!/bin/sh' > "$HOME/.tmux/plugins/tpm/bin/install_plugins"
+  echo 'exit 0' >> "$HOME/.tmux/plugins/tpm/bin/install_plugins"
+  chmod +x "$HOME/.tmux/plugins/tpm/bin/install_plugins"
+fi
+exit 0
+EOF
+  chmod +x "$mock_bin/git"
+  
+  # Export environment for bootstrap.sh to use the temp home and mock binaries
+  export HOME="$tmp_home"
+  export PATH="$mock_bin:$PATH"
+  
+  # Run bootstrap the first time (should succeed)
+  bash "$REPO_ROOT/bootstrap.sh"
+  
+  # Assert symlinks are valid and point to correct targets
+  [ -L "$tmp_home/.bash_profile" ]
+  [ -L "$tmp_home/.zshrc" ]
+  [ -L "$tmp_home/.gitconfig" ]
+  [ -L "$tmp_home/.local/bin/dotfiles_remote_browser_open.sh" ]
+  
+  # Run bootstrap the second time and capture output/exit status
+  run bash "$REPO_ROOT/bootstrap.sh"
+  
+  # Assert second run succeeded
+  assert_success
+  
+  # Assert no errors or failures printed on second run
+  refute_output --partial "error"
+  refute_output --partial "failed"
+  refute_output --partial "No such file"
+  refute_output --partial "ln:"
+  
+  # Assert ~/.ssh/config does not have duplicate blocks
+  if [ -f "$tmp_home/.ssh/config" ]; then
+    local count
+    count=$(grep -c "AddKeysToAgent" "$tmp_home/.ssh/config")
+    [ "$count" -le 1 ]
+  fi
+  
+  # Clean up
   rm -rf "$tmp_home"
-  [ "$dupes" -eq 0 ]
 }

--- a/tests/bootstrap_idempotency.bats
+++ b/tests/bootstrap_idempotency.bats
@@ -1,0 +1,27 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+@test "bootstrap: running twice does not duplicate lines in generated rc files" {
+  # Create a temp home directory to avoid polluting the real one
+  local tmp_home
+  tmp_home=$(mktemp -d)
+  
+  # Run bootstrap twice in a row with a temp HOME
+  HOME="$tmp_home" bash "$REPO_ROOT/bootstrap.sh" || true
+  HOME="$tmp_home" bash "$REPO_ROOT/bootstrap.sh" || true
+
+  # Check that no file has duplicate lines
+  local dupes=0
+  for f in "$tmp_home/.bash_profile" "$tmp_home/.zshrc" "$tmp_home/.gitconfig"; do
+    if [ -f "$f" ]; then
+      local d
+      d=$(sort "$f" | uniq -d | wc -l)
+      dupes=$((dupes + d))
+    fi
+  done
+
+  rm -rf "$tmp_home"
+  [ "$dupes" -eq 0 ]
+}


### PR DESCRIPTION

◐ dotfiles-5lh · Test bootstrap.sh idempotency   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-19 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

docs/PRODUCT.md claims bootstrap is idempotent ('Running bootstrap repeatedly must not break anything'), but this is not tested. A whole class of regressions (duplicated lines in generated rc files, re-symlinking failures, re-running brew installs) could slip in unnoticed.



ACCEPTANCE CRITERIA

A test (likely in tests/integration/ inside Docker) runs bootstrap.sh twice and asserts: exit code 0 both times; no duplicated lines in generated shell rc files; symlinks remain valid; no error output on second run.