### PR TITLE
chore: gitignore .agent/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ private
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db
+.agent/


### PR DESCRIPTION

◐ dotfiles-a27 · Document or gitignore .agent/ directory   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-19 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

There is a .agent/ hidden directory at repo root that is not mentioned in docs/ARCHITECTURE.md and is distinct from the tracked agent/ directory. Readers don't know what it is, whether it is local scratch state, or whether it should be tracked.



ACCEPTANCE CRITERIA

Either: (a) docs/ARCHITECTURE.md gains a one-liner explaining .agent/'s purpose, OR (b) .agent/ is added to .gitignore if it is local-only state. Decision recorded in the issue.