### PR TITLE
docs: document skills/ directory conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ just test           # Full test suite in Docker
 - Product and domain context → [docs/PRODUCT.md](docs/PRODUCT.md)
 - Security policies and secrets → [docs/SECURITY.md](docs/SECURITY.md)
 - Testing policy and bug fix guidance → [docs/TESTING.md](docs/TESTING.md)
-- Custom AI skills (Claude Code + opencode) → `skills/`
+- Custom AI skills (Claude Code + opencode) → `skills/` (see docs/DEVELOPMENT.md for authoring conventions)
 
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -118,3 +118,38 @@ needed beyond running `bootstrap.sh` on the remote machine.
 - **`gitconfig`**: GPG signing, useful aliases (`tree`, `tree-one`, `diff-word`, `forget`), LFS, SSH for GitHub, nvimdiff merge tool
 - **`alacritty.toml`**: Alacritty terminal emulator config
 - **`ripgreprc`**: Ripgrep defaults (exported via `RIPGREP_CONFIG_PATH`)
+
+## AI Skills
+
+The `skills/` directory contains custom AI agent skills used by both Claude Code and opencode.
+
+### Directory Layout
+
+Each skill lives in its own subdirectory under `skills/<skill-name>/` and must contain a `SKILL.md` file at minimum:
+
+```
+skills/
+  organize-ai-context/
+    SKILL.md
+```
+
+### SKILL.md Frontmatter
+
+The `SKILL.md` file must begin with YAML frontmatter:
+
+```yaml
+---
+name: organize-ai-context
+description: Use when setting up a new repository, when AI agents lack project context, or when codebase guidelines are scattered and unstructured.
+---
+```
+
+- `name`: matches the directory name (kebab-case)
+- `description`: a concise trigger phrase that tells the agent when to invoke the skill
+
+### Discovery Behavior
+
+- **Claude Code**: Skills are discovered from the `skills/` directory in the project root and from the user's global skills path.
+- **opencode**: Skills are discovered from the `skills/` directory in the project root and from `~/.config/opencode/skills/`. The opencode `skill` tool loads the full `SKILL.md` content on demand.
+
+When adding a new skill, ensure the frontmatter is valid YAML and the `name` matches the directory name exactly.


### PR DESCRIPTION

◐ dotfiles-1id · Document skills/ directory conventions   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-19 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

CLAUDE.md references skills/ but no doc explains authoring conventions, file layout, naming, or how skills are picked up by Claude Code vs opencode. Future-me (and other agents) have to reverse-engineer from the existing skills.



ACCEPTANCE CRITERIA

Either a new docs/SKILLS.md or a section in docs/DEVELOPMENT.md covering: directory layout, required frontmatter, naming conventions, and Claude Code vs opencode discovery behavior. CLAUDE.md context index links to it.