### PR TITLE
feat(platform): centralize Darwin/Linux guards in lib/platform.sh

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -95,8 +95,10 @@ bind "set show-all-if-ambiguous on"
 # Glob includes hidden files
 shopt -s dotglob
 
+. "$DOTFILES/lib/platform.sh"
+
 # Increase open files limit
-[ "$OS" == "Darwin" ] && ulimit -n 10000
+is_macos && ulimit -n 10000
 
 # Set hostname vars
 export HOSTNAME="$(hostname)"

--- a/lib/_shared.sh
+++ b/lib/_shared.sh
@@ -6,6 +6,8 @@ DOTFILES_HISTFILE_DELIM='^[0-9]{4}/[0-9]{2}//?[0-9]{2}[.][0-9]{2}[.][0-9]{2}[.][
 # Strips the shell history line prefix: '  NNN  YYYY-MM-DD HH:MM:SS '
 DOTFILES_HISTORY_DELIM='^ {0,4}[0-9]+  [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} '
 
+. "$DOTFILES/lib/platform.sh"
+
 # Helper functions
 function _dotfiles_full_path () {
   _z -e "$1"
@@ -33,7 +35,7 @@ function _dotfiles_grep_ticket_number () {
     e=$(echo "$d" | sed -E 's/^([0-9]{1,7})\_.*$/DCX\1/')
     # echo "e: $e" >&2
     # Filter out anything other than ab123 or abc-123 or DCX123
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    if is_macos; then
       f=$(echo "$e" | grep -E '^([a-zA-Z]{2}[0-9]{1,7}|[a-zA-Z0-9]{2,5}\-)\d{1,7}|DCX[0-9]{1,7}$')
     else
       f=$(echo "$e" | grep -P '^([a-zA-Z]{2}[0-9]{1,7}|[a-zA-Z0-9]{2,5}\-)\d{1,7}|DCX[0-9]{1,7}$')

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -700,7 +700,7 @@ function paste_from_clipboard ()
 
 function restart-docker ()
 {
-  if [[ "$OSTYPE" != "darwin"* ]]; then
+  if ! is_macos; then
     echo "restart-docker is not supported on Linux. Use: sudo systemctl restart docker"
     return 1
   fi

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -5,7 +5,7 @@ function notify ()
 
   local usage='Usage: notify [MESSAGE]'
 
-  [[ "$OSTYPE" != "darwin"* ]] && return 0
+  ! is_macos && return 0
 
   if [ ! $(which osascript) ]
   then

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Platform detection helpers
+# Usage: if is_macos; then ... fi
+# Usage: if is_linux; then ... fi
+
+function is_macos () {
+  [[ "$OSTYPE" == "darwin"* ]] || [[ "$(uname -s)" == "Darwin" ]]
+}
+
+function is_linux () {
+  [[ "$OSTYPE" == "linux"* ]] || [[ "$(uname -s)" == "Linux" ]]
+}

--- a/tests/platform_guards.bats
+++ b/tests/platform_guards.bats
@@ -6,8 +6,9 @@ setup() {
 
 # restart-docker guard
 @test "restart-docker exits 1 with error message on Linux" {
-  run bash -c "
-    OSTYPE=linux-gnu
+  run env OSTYPE=linux-gnu bash -c "
+    uname() { echo 'Linux'; }
+    export -f uname
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     restart-docker
@@ -20,12 +21,12 @@ setup() {
   # We can't fully run restart-docker (it calls osascript), but we can verify
   # the guard does NOT trigger (returns past the guard) on darwin.
   # Stub osascript and open to prevent actual Docker restart.
-  run bash -c "
-    OSTYPE=darwin20
+  run env OSTYPE=darwin20 bash -c "
+    uname() { echo 'Darwin'; }
     osascript() { return 0; }
     open() { return 0; }
     docker() { return 0; }
-    export -f osascript open docker
+    export -f uname osascript open docker
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     # Override wait loop to exit immediately

--- a/tests/platform_helpers.bats
+++ b/tests/platform_helpers.bats
@@ -1,0 +1,40 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+@test "platform: is_macos returns true on Darwin" {
+  run bash -c "
+    OSTYPE=darwin20
+    . '$REPO_ROOT/lib/platform.sh'
+    is_macos && echo 'yes' || echo 'no'
+  "
+  assert_output "yes"
+}
+
+@test "platform: is_macos returns false on Linux" {
+  run bash -c "
+    OSTYPE=linux-gnu
+    . '$REPO_ROOT/lib/platform.sh'
+    is_macos && echo 'yes' || echo 'no'
+  "
+  assert_output "no"
+}
+
+@test "platform: is_linux returns true on Linux" {
+  run bash -c "
+    OSTYPE=linux-gnu
+    . '$REPO_ROOT/lib/platform.sh'
+    is_linux && echo 'yes' || echo 'no'
+  "
+  assert_output "yes"
+}
+
+@test "platform: is_linux returns false on Darwin" {
+  run bash -c "
+    OSTYPE=darwin20
+    . '$REPO_ROOT/lib/platform.sh'
+    is_linux && echo 'yes' || echo 'no'
+  "
+  assert_output "no"
+}

--- a/tests/platform_helpers.bats
+++ b/tests/platform_helpers.bats
@@ -4,8 +4,9 @@ setup() {
 }
 
 @test "platform: is_macos returns true on Darwin" {
-  run bash -c "
-    OSTYPE=darwin20
+  run env OSTYPE=darwin20 bash -c "
+    uname() { echo 'Darwin'; }
+    export -f uname
     . '$REPO_ROOT/lib/platform.sh'
     is_macos && echo 'yes' || echo 'no'
   "
@@ -13,8 +14,9 @@ setup() {
 }
 
 @test "platform: is_macos returns false on Linux" {
-  run bash -c "
-    OSTYPE=linux-gnu
+  run env OSTYPE=linux-gnu bash -c "
+    uname() { echo 'Linux'; }
+    export -f uname
     . '$REPO_ROOT/lib/platform.sh'
     is_macos && echo 'yes' || echo 'no'
   "
@@ -22,8 +24,9 @@ setup() {
 }
 
 @test "platform: is_linux returns true on Linux" {
-  run bash -c "
-    OSTYPE=linux-gnu
+  run env OSTYPE=linux-gnu bash -c "
+    uname() { echo 'Linux'; }
+    export -f uname
     . '$REPO_ROOT/lib/platform.sh'
     is_linux && echo 'yes' || echo 'no'
   "
@@ -31,8 +34,9 @@ setup() {
 }
 
 @test "platform: is_linux returns false on Darwin" {
-  run bash -c "
-    OSTYPE=darwin20
+  run env OSTYPE=darwin20 bash -c "
+    uname() { echo 'Darwin'; }
+    export -f uname
     . '$REPO_ROOT/lib/platform.sh'
     is_linux && echo 'yes' || echo 'no'
   "

--- a/tests/test_helper/common_setup.bash
+++ b/tests/test_helper/common_setup.bash
@@ -7,11 +7,15 @@ load "${_helper_dir}/bats-assert/load"
 REPO_ROOT="$(cd "${_helper_dir}/../.." && pwd)"
 
 common_setup() {
+  # Ensure DOTFILES is defined so platform.sh can source correctly
+  export DOTFILES="$REPO_ROOT"
+
   # Source shared lib (order matters: _shared first)
   . "$REPO_ROOT/lib/_shared.sh"
   . "$REPO_ROOT/lib/commands.sh"
   # Export REPO_ROOT and all _dotfiles_* functions for use in bash -c subshells
   export REPO_ROOT
+  export -f is_macos is_linux
   while IFS= read -r _fn; do
     export -f "$_fn" 2>/dev/null || true
   done < <(declare -F | awk '{print $3}' | grep '^_dotfiles_')


### PR DESCRIPTION

◐ dotfiles-aqe · Centralize platform (Darwin/Linux) guards in lib/platform.sh   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-19 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

Darwin checks are scattered across multiple lib files and bash_profile. If Linux dev-machine usage grows beyond Docker/CI, this scatter makes cross-platform changes error-prone.



ACCEPTANCE CRITERIA

New lib/platform.sh exports is_macos / is_linux helpers. Existing Darwin checks migrated to call the helpers. Behavior unchanged; bats test covers both branches via mocked uname.