### PR TITLE
fix(bootstrap): warn when ~/.ssh/api_keys is missing

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -178,6 +178,8 @@ linkSkillsDir "$THIS_DIR/skills" "$HOME/.gemini/config/skills"
 if [ ! -f "$HOME/.ssh/api_keys" ]
 then
   touch "$HOME/.ssh/api_keys"
+
+  echo "WARNING: ~/.ssh/api_keys did not exist. Created empty file."
 fi
 
 # Setup ssh key


### PR DESCRIPTION

◐ dotfiles-pwb · Warn when ~/.ssh/api_keys is missing during bootstrap   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-19 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

~/.ssh/api_keys is silently skipped when absent (documented in docs/SECURITY.md). On a fresh machine or post-wipe, this means commits are unsigned and third-party integrations mysteriously fail with no signal. The silent-skip is intentional for shell startup but bootstrap.sh should be louder.



ACCEPTANCE CRITERIA

bootstrap.sh prints a clear warning (not an error) when ~/.ssh/api_keys is absent, listing which env vars will be missing (e.g. GIT_SIGNING_KEY). just doctor (if shipped) also surfaces this.