### PR TITLE
docs: fix inaccurate bootstrap flags documentation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@
 - **`bootstrap.sh`**: Main installation script
   - Creates symlinks from dotfiles to home directory (~/.bash_profile, ~/.vimrc, ~/.gitconfig, etc.)
   - Sets up directory structure (~/dev, ~/dev/go, etc.)
-  - Optionally installs dependencies with `-i` or `--install-deps` flag
+  - Installs dependencies automatically (Homebrew, mise, rustup, npm globals, etc.)
   - Configures SSH keys, GPG agent, tmux plugins
 
 - **`bash_profile`**: Main bash configuration loaded on shell startup


### PR DESCRIPTION
◐ dotfiles-doq · docs/architecture.md: fix inaccurate bootstrap flags documentation   [● P3 · IN_PROGRESS]
Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task
Created: 2026-04-18 · Started: 2026-05-31 · Updated: 2026-05-31

DESCRIPTION
docs/architecture.md:7-8 documents -i / --install-deps flags for bootstrap.sh, but the actual bootstrap.sh has no such flags — it always runs all installs. The rudimentary flags parsing at lines 6-11 only handles -h/--help. Either correct the docs or implement the flag if still desired.