### PR TITLE
test(goss): decouple node version assertion from mise lts alias

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -18,7 +18,7 @@ command:
   "node --version":
     exit-status: 0
     stdout:
-      - /^v24\./
+      - /^v2[0-9]\./
 
   # mise must be installed and functional
   "mise --version":


### PR DESCRIPTION

◐ dotfiles-iua · goss.yaml: decouple node version assertion from mise lts alias   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-18 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

goss.yaml:21 hardcodes node v24 in the stdout assertion while mise-config.toml uses node = "lts". When LTS moves to v26, the goss test will fail without touching mise-config.toml. Fix: either match v2[0-9] pattern, or explicitly pin the version in both files with a single source of truth.