### PR TITLE
chore(bash_profile): prune dead legacy PATH entries (Cloud9, jenv)

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -137,16 +137,9 @@ export PATH=$ANDROID_HOME/platform-tools:$ANDROID_HOME/tools:$ANDROID_HOME/tools
 # bun
 [ -d "$HOME/.bun/bin" ] && export PATH=$PATH:$HOME/.bun/bin
 
-# c9
-[ -d "/opt/c9/local/bin" ] && export PATH=$PATH:/opt/c9/local/bin
-
 # deno
 [ -d "$HOME/.deno" ] && export DENO_INSTALL="$HOME/.deno"
 [ -d "$DENO_INSTALL/bin" ] && export PATH="$DENO_INSTALL/bin:$PATH"
-
-# jenv
-[ -d "$HOME/.jenv/bin" ] && export PATH=$PATH:$HOME/.jenv/bin
-if which jenv > /dev/null; then eval "$(jenv init -)"; fi
 
 # maestro
 [ -d "$HOME/.maestro/bin" ] && export PATH=$PATH:$HOME/.maestro/bin


### PR DESCRIPTION

◐ dotfiles-m1f · bash_profile: prune dead legacy PATH entries (Cloud9, Antigravity, Torch, jenv, yarn)   [● P3 · IN_PROGRESS]

Owner: Aaron Tribou · Assignee: Aaron Tribou · Type: task

Created: 2026-04-18 · Started: 2026-05-31 · Updated: 2026-05-31



DESCRIPTION

bash_profile has several legacy dead PATH entries that accumulate tech debt: /opt/c9/local/bin (Cloud9 IDE, retired 2022), $DEVPATH/torch/install (Lua/Torch, unsupported since ~2017), and $HOME/.jenv (superseded by mise). Each is guarded by [ -d ... ] so they're safe no-ops, but slow down profile readability and signal stale thinking.\n\nNOTE: $HOME/.antigravity is intentionally kept — Antigravity 2.0 with the agy CLI was released in May 2026 and continues to use this path. Yarn support is also kept.



NOTES

Owner confirmed: keep yarn support. Research confirmed: .antigravity is actively used by Antigravity 2.0 / agy (May 2026 release). Only prune Cloud9, Torch, and jenv.