### PR TITLE
Make bootstrap upgrades non-interactive

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,6 +14,7 @@ fi
 # Get bootstrap script directory
 THIS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )
 export DOTFILES="$THIS_DIR"
+export NONINTERACTIVE=1
 
 function backupFile ()
 {
@@ -265,6 +266,21 @@ then
       echo
     fi
 
+    if command -v claude &>/dev/null
+    then
+      echo "Upgrading claude"
+      claude upgrade || true
+      echo
+    fi
+
+    OPENCODE_BIN="$(type -P opencode 2>/dev/null || true)"
+    if [ -n "$OPENCODE_BIN" ]
+    then
+      echo "Upgrading opencode"
+      "$OPENCODE_BIN" upgrade || true
+      echo
+    fi
+
     if [ -x "$MISE_BIN" ]
     then
       eval "$("$MISE_BIN" activate bash)"
@@ -298,6 +314,7 @@ then
   if [[ "$OSTYPE" != "darwin"* ]]; then
     if command -v apt-get &>/dev/null; then
       sudo apt-get update
+      sudo apt-get upgrade -y
       sudo apt-get install -y curl git build-essential xdg-utils bash-completion
     elif command -v pacman &>/dev/null; then
       sudo pacman -Syu --noconfirm curl git base-devel bash-completion

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -7,6 +7,23 @@ setup() {
   grep -q 'NONINTERACTIVE=1' "$REPO_ROOT/bootstrap.sh"
 }
 
+@test "bootstrap: exports NONINTERACTIVE=1 near the top for all Homebrew commands" {
+  awk 'NR <= 25 && /export NONINTERACTIVE=1/{found=1} END{exit !found}' "$REPO_ROOT/bootstrap.sh"
+}
+
+@test "bootstrap: claude upgrade is gated behind command -v claude" {
+  awk '/command -v claude/,/claude upgrade/' "$REPO_ROOT/bootstrap.sh" | grep -q 'claude upgrade'
+}
+
+@test "bootstrap: opencode upgrade is gated behind type -P opencode, not command -v" {
+  awk '/OPENCODE_BIN=.*type -P opencode/,/opencode.*upgrade/' "$REPO_ROOT/bootstrap.sh" | grep -q '"$OPENCODE_BIN" upgrade'
+  ! awk '/OPENCODE_BIN/,/opencode.*upgrade/' "$REPO_ROOT/bootstrap.sh" | grep -q 'command -v opencode'
+}
+
+@test "bootstrap: apt-get block upgrades packages non-interactively after update" {
+  awk '/command -v apt-get/,/apt-get install/' "$REPO_ROOT/bootstrap.sh" | awk '/apt-get update/{updated=1} updated && /apt-get upgrade -y/{upgraded=1} END{exit !upgraded}'
+}
+
 @test "bootstrap: calls hash -r after mise install node to pick up newly created shims" {
   awk '/mise install node go/{found=1} found && /hash -r/{found=2} END{exit (found!=2)}' "$REPO_ROOT/bootstrap.sh"
 }


### PR DESCRIPTION
### Motivation

- Reduce interactive prompts during machine bootstrap by making Homebrew installs non-interactive and adding automated upgrade steps for developer tools. 
- Ensure system packages on Debian/Ubuntu are fully upgraded non-interactively during bootstrap. 
- Keep optional tool upgrades (Claude Code, opencode) guarded and safe so they only run when the real executables are present. 
- Add tests to assert these behaviors so the script remains non-interactive and correctly gated.

### Description

- Export `NONINTERACTIVE=1` near the top of `bootstrap.sh` so all subsequent Homebrew invocations run non-interactively. 
- Add a guarded `claude upgrade` step using `command -v claude` and tolerant failure handling. 
- Add an `opencode` upgrade guarded by `OPENCODE_BIN="$(type -P opencode 2>/dev/null || true)"` so only real executables (not aliases/functions) are upgraded. 
- Add `sudo apt-get upgrade -y` after `sudo apt-get update` in the Linux apt block. 
- Extend `tests/bootstrap.bats` with tests that assert `export NONINTERACTIVE=1` is present, that `claude upgrade` is gated with `command -v`, that `opencode` upgrade uses `type -P`, and that the apt-get block contains `apt-get upgrade -y`.

### Testing

- Ran unit tests for the bootstrap area with `mise x just -- env USER=${USER:-root} just test-unit tests/bootstrap.bats`, and the new bootstrap-related bats passed. 
- Ran the full unit test suite with `mise x just -- env USER=${USER:-root} just test-unit`, which completed successfully. 
- `git diff --check` showed no whitespace/fixable issues. 
- `bashcheck bootstrap.sh` could not be executed because `bashcheck` is not installed in the environment, and `just test` (full integration tests) could not be run because Docker is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7708cf30833282582b006f30b3dd)