### PR TITLE
feat(commit): AI-generated commit messages via Claude Haiku

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
+      - name: Install shellcheck
+        run: brew install shellcheck
+
       - name: Run bash function tests
         run: just test-unit

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     fzf \
     fd-find \
     bat \
+    git-delta \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install --break-system-packages pynvim \
   && ln -s /usr/bin/fdfind /usr/local/bin/fd \

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,6 +40,8 @@ gpsu                           # git push -u origin current-branch
 
 - Commit separator configurable via `DOTFILES_COMMIT_SEPARATOR` (default: `:`)
 
+`commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors.
+
 ## Package Management
 
 ```bash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,7 +40,7 @@ gpsu                           # git push -u origin current-branch
 
 - Commit separator configurable via `DOTFILES_COMMIT_SEPARATOR` (default: `:`)
 
-`commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors.
+`commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors. A spinner shows progress while waiting; Ctrl-C cancels the commit (changes stay staged) instead of falling back to `c`.
 
 ## Package Management
 

--- a/docs/superpowers/plans/2026-06-20-commit-haiku.md
+++ b/docs/superpowers/plans/2026-06-20-commit-haiku.md
@@ -1,0 +1,671 @@
+# `commit` — AI-Generated Commit via Claude Haiku Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `alias commit='git commit -ev'` in `lib/commands.sh` with a `commit` shell function that stages everything, asks Claude Haiku to draft a one-line commit message from the staged diff, and commits — falling back to the existing `c` function whenever Haiku is unavailable, errors, or returns nothing usable.
+
+**Architecture:** Three small `_dotfiles_commit_*` helpers (sanitize output, build the model prompt, run Haiku and produce a clean message) compose into the public `commit` function. Each helper is independently unit-tested with mocked `git`/`claude`; `commit` itself is tested with all of its collaborators mocked.
+
+**Tech Stack:** Bash, bats-core, the `claude` CLI in print mode (`-p --model haiku`)
+
+## Global Constraints
+
+- Commits in this repo are single-line only via `git commit -m "..."`, no `Co-Authored-By` line (applies to the commits this plan's steps make, not just the feature under test).
+- Bash syntax/lint checks use `bashcheck`, never `bash -n` directly.
+- New behavior requires bats tests under `tests/` (TDD: failing test → implementation → passing test).
+- The staged diff sent to Haiku is capped at 100000 bytes (`head -c 100000`) before piping into `claude -p --model haiku`.
+- `claude` is invoked in print mode (`-p`) so it only emits text — no tools, no permission prompts, no git calls from the model itself.
+- When a ticket is present, the model must NOT add a Conventional Commits prefix (the ticket prefix is added separately by `_dotfiles_commit_message`, and stacking both would read like `AB-123: fix(scope): ...`). When no ticket is present, Conventional Commits style is allowed.
+- Any fallback path (`claude` missing, non-zero exit, or empty output after sanitizing) prints a short note to stderr and calls the existing `c` function — never aborts uncommitted.
+- Out of scope: confirmation prompt before committing, pushing after commit, making the model configurable (hard-coded to `haiku`).
+
+---
+
+### Task 1: Commit message sanitizer helper
+
+**Files:**
+- Modify: `lib/commands.sh` (insert after the `cn` function, before `clean()` — currently lines 69-71)
+- Test: Create `tests/commit_sanitize_message.bats`
+
+**Interfaces:**
+- Produces: `_dotfiles_commit_sanitize_message "$raw_text"` — echoes the first line of `$raw_text` with surrounding quotes/backticks/whitespace stripped. Empty input produces empty output. Consumed by Task 2's `_dotfiles_commit_generate_message`.
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `tests/commit_sanitize_message.bats`:
+
+  ```bash
+  setup() {
+    load 'test_helper/common_setup'
+    common_setup
+  }
+
+  @test "passes through a clean single-line message unchanged" {
+    run _dotfiles_commit_sanitize_message "fix the thing"
+    assert_output "fix the thing"
+  }
+
+  @test "strips surrounding double quotes" {
+    run _dotfiles_commit_sanitize_message '"fix the thing"'
+    assert_output "fix the thing"
+  }
+
+  @test "strips surrounding single quotes" {
+    run _dotfiles_commit_sanitize_message "'fix the thing'"
+    assert_output "fix the thing"
+  }
+
+  @test "strips surrounding backticks" {
+    run _dotfiles_commit_sanitize_message '`fix the thing`'
+    assert_output "fix the thing"
+  }
+
+  @test "strips leading and trailing whitespace" {
+    run _dotfiles_commit_sanitize_message "   fix the thing   "
+    assert_output "fix the thing"
+  }
+
+  @test "takes only the first line of multi-line output" {
+    run _dotfiles_commit_sanitize_message "$(printf 'fix the thing\nsome extra explanation\nmore text')"
+    assert_output "fix the thing"
+  }
+
+  @test "reduces multi-line quoted output to a clean single line" {
+    run _dotfiles_commit_sanitize_message "$(printf '"fix(bootstrap): silence brew prompt"\nThis change updates the bootstrap script.')"
+    assert_output "fix(bootstrap): silence brew prompt"
+  }
+
+  @test "empty input produces empty output" {
+    run _dotfiles_commit_sanitize_message ""
+    assert_output ""
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_sanitize_message.bats`
+  Expected: every test FAILs with `_dotfiles_commit_sanitize_message: command not found`
+
+- [ ] **Step 3: Implement the helper**
+
+  In `lib/commands.sh`, find this exact block (the end of the `cn` function, lines 67-71):
+
+  ```bash
+    fi
+  }
+
+  function clean ()
+  ```
+
+  Replace it with:
+
+  ```bash
+    fi
+  }
+
+  function _dotfiles_commit_sanitize_message ()
+  {
+    printf '%s' "$1" | head -n1 | sed -E "s/^[\"'\`[:space:]]+//; s/[\"'\`[:space:]]+$//"
+  }
+
+  function clean ()
+  ```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_sanitize_message.bats`
+  Expected: all 8 tests PASS
+
+- [ ] **Step 5: Run bashcheck**
+
+  Run: `bashcheck lib/commands.sh tests/commit_sanitize_message.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add lib/commands.sh tests/commit_sanitize_message.bats
+  git commit -m "feat(commit): add commit message sanitizer helper"
+  ```
+
+---
+
+### Task 2: AI message generation helper
+
+**Files:**
+- Modify: `lib/commands.sh` (insert after `_dotfiles_commit_sanitize_message`, before `clean()`)
+- Test: Create `tests/commit_generate_message.bats`
+
+**Interfaces:**
+- Consumes: `_dotfiles_commit_sanitize_message` (Task 1)
+- Produces:
+  - `_dotfiles_commit_prompt "$ticket"` — echoes the prompt text to send to Haiku; wording depends on whether `$ticket` is non-empty.
+  - `_dotfiles_commit_generate_message "$ticket"` — on success, echoes the sanitized model message and returns 0; on any failure (claude missing, non-zero exit, empty output after sanitizing), prints nothing and returns 1. Consumed by Task 3's `commit`.
+
+- [ ] **Step 1: Write the failing tests for `_dotfiles_commit_prompt`**
+
+  Create `tests/commit_generate_message.bats`:
+
+  ```bash
+  setup() {
+    load 'test_helper/common_setup'
+    common_setup
+  }
+
+  # --- _dotfiles_commit_prompt ---
+
+  @test "prompt: ticket present requests a plain summary with no Conventional Commits prefix" {
+    run _dotfiles_commit_prompt "AB-123"
+    assert_success
+    refute_output --partial "Conventional Commits"
+  }
+
+  @test "prompt: no ticket allows Conventional Commits style" {
+    run _dotfiles_commit_prompt ""
+    assert_success
+    assert_output --partial "Conventional Commits"
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_generate_message.bats`
+  Expected: both tests FAIL with `_dotfiles_commit_prompt: command not found`
+
+- [ ] **Step 3: Implement `_dotfiles_commit_prompt`**
+
+  In `lib/commands.sh`, find this exact block (the `_dotfiles_commit_sanitize_message` function added in Task 1):
+
+  ```bash
+  function _dotfiles_commit_sanitize_message ()
+  {
+    printf '%s' "$1" | head -n1 | sed -E "s/^[\"'\`[:space:]]+//; s/[\"'\`[:space:]]+$//"
+  }
+
+  function clean ()
+  ```
+
+  Replace it with:
+
+  ```bash
+  function _dotfiles_commit_sanitize_message ()
+  {
+    printf '%s' "$1" | head -n1 | sed -E "s/^[\"'\`[:space:]]+//; s/[\"'\`[:space:]]+$//"
+  }
+
+  function _dotfiles_commit_prompt ()
+  {
+    local ticket="$1"
+
+    if [ -n "$ticket" ]
+    then
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use plain imperative mood (e.g. "fix the thing"). Do not add a type or scope prefix like "feat:" or "fix(scope):" -- a ticket prefix will be added separately. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    else
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use Conventional Commits style (e.g. "fix(scope): summary") when it fits, otherwise a plain imperative summary. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    fi
+  }
+
+  function clean ()
+  ```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_generate_message.bats`
+  Expected: both tests PASS
+
+- [ ] **Step 5: Append the failing tests for `_dotfiles_commit_generate_message`**
+
+  Append to `tests/commit_generate_message.bats` (after the two prompt tests, inside the same file):
+
+  ```bash
+
+  # --- _dotfiles_commit_generate_message ---
+
+  @test "generate_message: returns claude's sanitized output on success" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { echo 'fix(bootstrap): silence brew prompt'; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_success
+    assert_output "fix(bootstrap): silence brew prompt"
+  }
+
+  @test "generate_message: fails when claude is not found on PATH" {
+    local empty_path
+    empty_path="$(mktemp -d)"
+    run bash -c "
+      export PATH='$empty_path'
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+    rm -rf "$empty_path"
+  }
+
+  @test "generate_message: fails when claude exits non-zero" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { return 1; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+  }
+
+  @test "generate_message: fails when claude returns empty output" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo ''; }
+      claude() { echo ''; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+  }
+
+  @test "generate_message: caps the diff sent to claude at 100000 bytes" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { yes a | head -c 200000; }
+      claude() { wc -c | tr -d ' '; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_success
+    assert_output "100000"
+  }
+  ```
+
+- [ ] **Step 6: Run the tests to verify the new ones fail**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_generate_message.bats`
+  Expected: the 2 prompt tests PASS, the 5 new `generate_message` tests FAIL with `_dotfiles_commit_generate_message: command not found`
+
+- [ ] **Step 7: Implement `_dotfiles_commit_generate_message`**
+
+  In `lib/commands.sh`, find this exact block (the `_dotfiles_commit_prompt` function added in Step 3 above):
+
+  ```bash
+  function _dotfiles_commit_prompt ()
+  {
+    local ticket="$1"
+
+    if [ -n "$ticket" ]
+    then
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use plain imperative mood (e.g. "fix the thing"). Do not add a type or scope prefix like "feat:" or "fix(scope):" -- a ticket prefix will be added separately. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    else
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use Conventional Commits style (e.g. "fix(scope): summary") when it fits, otherwise a plain imperative summary. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    fi
+  }
+
+  function clean ()
+  ```
+
+  Replace it with:
+
+  ```bash
+  function _dotfiles_commit_prompt ()
+  {
+    local ticket="$1"
+
+    if [ -n "$ticket" ]
+    then
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use plain imperative mood (e.g. "fix the thing"). Do not add a type or scope prefix like "feat:" or "fix(scope):" -- a ticket prefix will be added separately. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    else
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use Conventional Commits style (e.g. "fix(scope): summary") when it fits, otherwise a plain imperative summary. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    fi
+  }
+
+  function _dotfiles_commit_generate_message ()
+  {
+    local ticket="$1"
+
+    if ! command -v claude > /dev/null 2>&1
+    then
+      return 1
+    fi
+
+    local raw
+    if ! raw=$(git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")")
+    then
+      return 1
+    fi
+
+    local sanitized
+    sanitized=$(_dotfiles_commit_sanitize_message "$raw")
+
+    if [ -z "$sanitized" ]
+    then
+      return 1
+    fi
+
+    printf '%s' "$sanitized"
+  }
+
+  function clean ()
+  ```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_generate_message.bats`
+  Expected: all 7 tests PASS
+
+- [ ] **Step 9: Run bashcheck**
+
+  Run: `bashcheck lib/commands.sh tests/commit_generate_message.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add lib/commands.sh tests/commit_generate_message.bats
+  git commit -m "feat(commit): add AI commit message generation helper"
+  ```
+
+---
+
+### Task 3: `commit` function, alias removal, and doc update
+
+**Files:**
+- Modify: `lib/commands.sh` (insert `commit` function after `_dotfiles_commit_generate_message`, before `clean()`; remove the `alias commit='git commit -ev' # non-signed commit` line currently near the aliases section)
+- Modify: `docs/DEVELOPMENT.md` (document the new `commit` function next to the existing `c` documentation)
+- Test: Create `tests/commit_command.bats`
+
+**Interfaces:**
+- Consumes: `_dotfiles_grep_ticket_number`, `_dotfiles_commit_message`, `_dotfiles_git_log_commit`, `_dotfiles_git_status` (existing, `lib/_shared.sh`); `_dotfiles_commit_generate_message` (Task 2); `c` (existing, `lib/commands.sh`)
+- Produces: `commit` — the public-facing function with no required arguments.
+
+- [ ] **Step 1: Write the failing tests for `commit`'s behavior**
+
+  Create `tests/commit_command.bats`:
+
+  ```bash
+  setup() {
+    load 'test_helper/common_setup'
+    common_setup
+  }
+
+  @test "commit: ticket present builds TICKET: <summary> and commits" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() {
+        if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+        if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+        if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'feature/ABC-123-b'; return 0; fi
+        if [ \"\$1\" = \"commit\" ] && [ \"\$2\" = \"-m\" ]; then echo \"git_commit_message:\$3\"; return 0; fi
+      }
+      _dotfiles_commit_generate_message() { echo 'silence brew prompt'; }
+      _dotfiles_git_log_commit() { echo 'git_log_commit'; }
+      _dotfiles_git_status() { echo 'git_status'; }
+      commit
+    "
+    assert_success
+    assert_output --partial "git_commit_message:ABC-123: silence brew prompt"
+    assert_output --partial "git_log_commit"
+    assert_output --partial "git_status"
+  }
+
+  @test "commit: no ticket uses the generated message verbatim" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() {
+        if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+        if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+        if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+        if [ \"\$1\" = \"commit\" ] && [ \"\$2\" = \"-m\" ]; then echo \"git_commit_message:\$3\"; return 0; fi
+      }
+      _dotfiles_commit_generate_message() { echo 'fix(bootstrap): silence brew prompt'; }
+      _dotfiles_git_log_commit() { echo 'git_log_commit'; }
+      _dotfiles_git_status() { echo 'git_status'; }
+      commit
+    "
+    assert_success
+    assert_output --partial "git_commit_message:fix(bootstrap): silence brew prompt"
+    refute_output --partial "git_commit_message:ABC"
+  }
+
+  @test "commit: nothing staged prints message and skips commit" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() {
+        if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+        if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 0; fi
+        echo \"git_unexpected_call:\$*\"
+        return 0
+      }
+      _dotfiles_commit_generate_message() { echo 'should-not-be-called'; }
+      commit
+    "
+    assert_success
+    assert_output "nothing to commit"
+    refute_output --partial "should-not-be-called"
+    refute_output --partial "git_unexpected_call"
+  }
+
+  @test "commit: falls back to c when message generation fails" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() {
+        if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+        if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+        if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+        echo \"git_commit_message:unexpected\"
+        return 0
+      }
+      _dotfiles_commit_generate_message() { return 1; }
+      c() { echo 'c_invoked'; }
+      commit
+    "
+    assert_success
+    assert_output --partial "claude unavailable, falling back to manual commit"
+    assert_output --partial "c_invoked"
+    refute_output --partial "git_commit_message"
+  }
+  ```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_command.bats`
+  Expected: all 4 tests FAIL with `commit: command not found`
+
+- [ ] **Step 3: Implement `commit`**
+
+  In `lib/commands.sh`, find this exact block (the `_dotfiles_commit_generate_message` function added in Task 2):
+
+  ```bash
+  function _dotfiles_commit_generate_message ()
+  {
+    local ticket="$1"
+
+    if ! command -v claude > /dev/null 2>&1
+    then
+      return 1
+    fi
+
+    local raw
+    if ! raw=$(git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")")
+    then
+      return 1
+    fi
+
+    local sanitized
+    sanitized=$(_dotfiles_commit_sanitize_message "$raw")
+
+    if [ -z "$sanitized" ]
+    then
+      return 1
+    fi
+
+    printf '%s' "$sanitized"
+  }
+
+  function clean ()
+  ```
+
+  Replace it with:
+
+  ```bash
+  function _dotfiles_commit_generate_message ()
+  {
+    local ticket="$1"
+
+    if ! command -v claude > /dev/null 2>&1
+    then
+      return 1
+    fi
+
+    local raw
+    if ! raw=$(git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")")
+    then
+      return 1
+    fi
+
+    local sanitized
+    sanitized=$(_dotfiles_commit_sanitize_message "$raw")
+
+    if [ -z "$sanitized" ]
+    then
+      return 1
+    fi
+
+    printf '%s' "$sanitized"
+  }
+
+  function commit ()
+  {
+    git add -A
+
+    if git diff --cached --quiet
+    then
+      echo "nothing to commit"
+      return 0
+    fi
+
+    local ticket
+    ticket=$(git branch --show-current 2> /dev/null | _dotfiles_grep_ticket_number)
+
+    local generated
+    generated=$(_dotfiles_commit_generate_message "$ticket")
+
+    if [ -z "$generated" ]
+    then
+      echo "claude unavailable, falling back to manual commit" >&2
+      c
+      return
+    fi
+
+    local message
+    message=$(_dotfiles_commit_message "$ticket" "$generated")
+
+    git commit -m "$message" && _dotfiles_git_log_commit && _dotfiles_git_status
+  }
+
+  function clean ()
+  ```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_command.bats`
+  Expected: all 4 tests PASS
+
+- [ ] **Step 5: Write the failing regression test for alias removal**
+
+  Append to `tests/commit_command.bats`:
+
+  ```bash
+
+  @test "commit: removes the old non-AI alias" {
+    run grep -F "alias commit=" "$REPO_ROOT/lib/commands.sh"
+    assert_failure
+  }
+  ```
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_command.bats`
+  Expected: the new test FAILS (grep finds `alias commit='git commit -ev' # non-signed commit`)
+
+- [ ] **Step 6: Remove the old alias**
+
+  In `lib/commands.sh`, find this exact block (in the aliases section):
+
+  ```bash
+  alias cos='co staging'
+  alias commit='git commit -ev' # non-signed commit
+  alias convert-crlf-lf='git ls-files -z | xargs -0 dos2unix'
+  ```
+
+  Replace it with:
+
+  ```bash
+  alias cos='co staging'
+  alias convert-crlf-lf='git ls-files -z | xargs -0 dos2unix'
+  ```
+
+- [ ] **Step 7: Run the tests to verify they all pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_command.bats`
+  Expected: all 5 tests PASS
+
+- [ ] **Step 8: Document the new function**
+
+  In `docs/DEVELOPMENT.md`, find this exact line (in the "Git Workflow with Ticket Numbers" section):
+
+  ```markdown
+  - Commit separator configurable via `DOTFILES_COMMIT_SEPARATOR` (default: `:`)
+  ```
+
+  Replace it with:
+
+  ```markdown
+  - Commit separator configurable via `DOTFILES_COMMIT_SEPARATOR` (default: `:`)
+
+  `commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors.
+  ```
+
+- [ ] **Step 9: Run bashcheck**
+
+  Run: `bashcheck lib/commands.sh tests/commit_command.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 10: Commit**
+
+  ```bash
+  git add lib/commands.sh tests/commit_command.bats docs/DEVELOPMENT.md
+  git commit -m "feat(commit): add AI-generated commit function, replace git commit -ev alias"
+  ```
+
+---
+
+### Task 4: Full suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run bashcheck across all changed files**
+
+  Run: `bashcheck lib/commands.sh tests/commit_sanitize_message.bats tests/commit_generate_message.bats tests/commit_command.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 2: Run the fast unit suite**
+
+  Run: `just test-unit`
+  Expected: all tests pass, including the 8 + 7 + 5 new tests added in Tasks 1-3
+
+- [ ] **Step 3: Run the full Docker suite**
+
+  Run: `just test`
+  Expected: all bats integration tests and goss infrastructure checks pass
+
+- [ ] **Step 4: Fix forward if anything fails**
+
+  If any step above fails, fix the regression in the relevant task's files, re-run the failing command until it passes, then commit the fix with a message describing what broke (e.g. `git commit -m "fix(commit): correct sed escaping in sanitizer"`). Do not skip ahead — Task 4 is the final gate before the feature is considered done.

--- a/docs/superpowers/plans/2026-06-21-commit-progress-spinner.md
+++ b/docs/superpowers/plans/2026-06-21-commit-progress-spinner.md
@@ -1,0 +1,653 @@
+# `commit` — Animated Spinner While Claude Generates the Message Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a spinner to `commit` (`lib/commands.sh`) so the user gets visual feedback while `_dotfiles_commit_generate_message` waits on the `claude -p --model haiku` call, and let Ctrl-C cleanly cancel that wait instead of falling back to a manual commit editor.
+
+**Architecture:** A new `_dotfiles_spinner_wait <pid> <label>` helper watches an already-backgrounded process: it polls with `kill -0`, animates a braille spinner on stderr when stderr is a tty (a static label line otherwise), and traps SIGINT to kill the watched process and return `130` on cancel. `_dotfiles_commit_generate_message` backgrounds its existing `git diff | head -c | claude` pipeline (redirecting only stdout to a temp file) and delegates the wait to this helper, propagating `130` distinctly from other failures. `commit` checks for that `130` and exits without falling back to `c`.
+
+**Tech Stack:** Bash, bats-core (`run --separate-stderr` for stdout/stderr-split assertions), the `claude` CLI in print mode.
+
+## Global Constraints
+
+- All `_dotfiles_spinner_wait` output goes to stderr, never stdout — `_dotfiles_commit_generate_message` is captured via `generated=$(...)` in `commit()`, so any stray stdout would corrupt the generated commit message.
+- Interrupt handling (Ctrl-C) is unconditional, independent of the tty check — the backgrounded pipeline runs in its own process group and does not receive the terminal's SIGINT itself.
+- `trap 'interrupted=1' INT` is installed once at the top of `_dotfiles_spinner_wait`, before the tty check, and explicitly cleared (`trap - INT`) before every `return`. The trap only sets a flag — it never calls `return`/`exit` itself, because this function runs sourced into the user's live interactive shell, where `exit` inside a trap would close their terminal.
+- tty detection checks **stderr**, not stdout: `[ -t 2 ]`.
+- Normal (non-interrupted) completion returns the watched process's real exit status via `wait "$pid"`.
+- Out of scope: a timeout for a hung `claude` call, spinners around `git add`/`git commit` (instant, no feedback needed), preserving/restoring a pre-existing `INT` trap.
+- Bash syntax/lint checks use `bashcheck`, never `bash -n` directly.
+- New behavior requires bats tests under `tests/` (TDD: failing test → implementation → passing test).
+
+---
+
+### Task 1: `_dotfiles_spinner_wait` helper
+
+**Files:**
+- Modify: `lib/commands.sh` (insert after `_dotfiles_commit_prompt`, currently lines 77-87, before `_dotfiles_commit_generate_message`, currently starting line 89)
+- Test: Create `tests/spinner_wait.bats`
+
+**Interfaces:**
+- Produces: `_dotfiles_spinner_wait <pid> <label>` — watches the process `<pid>` (already started in the background by the caller). Returns the watched process's real exit status on normal completion. On SIGINT, kills `<pid>` and returns `130`. Writes only to stderr, nothing to stdout. Consumed by Task 2's `_dotfiles_commit_generate_message`.
+
+- [ ] **Step 1: Write the failing tests**
+
+  Create `tests/spinner_wait.bats`:
+
+  ```bash
+  setup() {
+    load 'test_helper/common_setup'
+    common_setup
+  }
+
+  @test "spinner_wait: returns 0 when the watched process exits 0, label printed to stderr" {
+    run --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      sleep 0.2 &
+      pid=\$!
+      _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...'
+    "
+    assert_success
+    assert_output ""
+    echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+  }
+
+  @test "spinner_wait: returns the watched process's nonzero exit status" {
+    run -7 --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      (sleep 0.1; exit 7) &
+      pid=\$!
+      _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...'
+    "
+    assert_output ""
+  }
+
+  @test "spinner_wait: SIGINT kills the watched pid and returns 130 with no stdout output" {
+    run -130 --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      sleep 5 &
+      pid=\$!
+      ( sleep 0.2; kill -INT \$\$ ) &
+      _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...'
+      status=\$?
+      sleep 0.2
+      if kill -0 \"\$pid\" 2>/dev/null; then
+        echo 'pid_still_alive' >&2
+      else
+        echo 'pid_killed' >&2
+      fi
+      exit \"\$status\"
+    "
+    assert_output ""
+    echo "$stderr" | grep -qF 'pid_killed'
+  }
+  ```
+
+  Note: the `sleep 0.2` after `_dotfiles_spinner_wait` returns gives the killed process time to actually terminate before checking — `kill` is asynchronous, so checking `kill -0` immediately after sending the signal is racy and would usually report the pid as still alive.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/spinner_wait.bats`
+  Expected: all 3 tests FAIL with `_dotfiles_spinner_wait: command not found`
+
+- [ ] **Step 3: Implement `_dotfiles_spinner_wait`**
+
+  In `lib/commands.sh`, find this exact block (the end of `_dotfiles_commit_prompt`):
+
+  ```bash
+  function _dotfiles_commit_prompt ()
+  {
+    local ticket="$1"
+
+    if [ -n "$ticket" ]
+    then
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use plain imperative mood (e.g. "fix the thing"). Do not add a type or scope prefix like "feat:" or "fix(scope):" -- a ticket prefix will be added separately. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    else
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use Conventional Commits style (e.g. "fix(scope): summary") when it fits, otherwise a plain imperative summary. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    fi
+  }
+
+  function _dotfiles_commit_generate_message ()
+  ```
+
+  Replace it with:
+
+  ```bash
+  function _dotfiles_commit_prompt ()
+  {
+    local ticket="$1"
+
+    if [ -n "$ticket" ]
+    then
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use plain imperative mood (e.g. "fix the thing"). Do not add a type or scope prefix like "feat:" or "fix(scope):" -- a ticket prefix will be added separately. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    else
+      printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use Conventional Commits style (e.g. "fix(scope): summary") when it fits, otherwise a plain imperative summary. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+    fi
+  }
+
+  function _dotfiles_spinner_wait ()
+  {
+    local pid="$1"
+    local label="$2"
+    local interrupted=0
+    local is_tty=0
+    local frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+    local frame_index=0
+
+    trap 'interrupted=1' INT
+
+    if [ -t 2 ]
+    then
+      is_tty=1
+    else
+      printf '%s\n' "$label" >&2
+    fi
+
+    while kill -0 "$pid" 2> /dev/null
+    do
+      if [ "$interrupted" -eq 1 ]
+      then
+        kill "$pid" 2> /dev/null
+        [ "$is_tty" -eq 1 ] && printf '\r\033[K' >&2
+        trap - INT
+        return 130
+      fi
+
+      if [ "$is_tty" -eq 1 ]
+      then
+        printf '\r%s %s' "${frames[frame_index]}" "$label" >&2
+        frame_index=$(( (frame_index + 1) % 10 ))
+      fi
+
+      sleep 0.1
+    done
+
+    [ "$is_tty" -eq 1 ] && printf '\r\033[K' >&2
+
+    wait "$pid"
+    local status=$?
+    trap - INT
+    return "$status"
+  }
+
+  function _dotfiles_commit_generate_message ()
+  ```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/spinner_wait.bats`
+  Expected: all 3 tests PASS
+
+- [ ] **Step 5: Run bashcheck**
+
+  Run: `bashcheck lib/commands.sh tests/spinner_wait.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add lib/commands.sh tests/spinner_wait.bats
+  git commit -m "feat(commit): add spinner_wait helper for animated progress"
+  ```
+
+---
+
+### Task 2: Wire the spinner into `_dotfiles_commit_generate_message`
+
+**Files:**
+- Modify: `lib/commands.sh` (currently lines 89-113)
+- Modify: `tests/commit_generate_message.bats`
+
+**Interfaces:**
+- Consumes: `_dotfiles_spinner_wait` (Task 1)
+- Produces: `_dotfiles_commit_generate_message "$ticket"` — unchanged success/empty-output contract, plus: returns `130` (instead of `1`) specifically when the wait was interrupted. Consumed by Task 3's `commit`.
+
+- [ ] **Step 1: Update the existing tests for the new stderr label line**
+
+  In `tests/commit_generate_message.bats`, find this exact block:
+
+  ```bash
+  @test "generate_message: returns claude's sanitized output on success" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { echo 'fix(bootstrap): silence brew prompt'; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_success
+    assert_output "fix(bootstrap): silence brew prompt"
+  }
+  ```
+
+  Replace it with:
+
+  ```bash
+  @test "generate_message: returns claude's sanitized output on success" {
+    run --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { echo 'fix(bootstrap): silence brew prompt'; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_success
+    assert_output "fix(bootstrap): silence brew prompt"
+    echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+  }
+  ```
+
+  Find this exact block:
+
+  ```bash
+  @test "generate_message: fails when claude exits non-zero" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { return 1; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+  }
+  ```
+
+  Replace it with:
+
+  ```bash
+  @test "generate_message: fails when claude exits non-zero" {
+    run --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { return 1; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+    echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+  }
+  ```
+
+  Find this exact block:
+
+  ```bash
+  @test "generate_message: fails when claude returns empty output" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo ''; }
+      claude() { echo ''; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+  }
+  ```
+
+  Replace it with:
+
+  ```bash
+  @test "generate_message: fails when claude returns empty output" {
+    run --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo ''; }
+      claude() { echo ''; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_failure
+    assert_output ""
+    echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+  }
+  ```
+
+  Find this exact block:
+
+  ```bash
+  @test "generate_message: caps the diff sent to claude at 100000 bytes" {
+    run bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { yes a | head -c 200000; }
+      claude() { wc -c | tr -d ' '; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_success
+    assert_output "100000"
+  }
+  ```
+
+  Replace it with:
+
+  ```bash
+  @test "generate_message: caps the diff sent to claude at 100000 bytes" {
+    run --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { yes a | head -c 200000; }
+      claude() { wc -c | tr -d ' '; }
+      _dotfiles_commit_generate_message ''
+    "
+    assert_success
+    assert_output "100000"
+    echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+  }
+
+  @test "generate_message: returns 130 and emits no stdout when interrupted" {
+    run -130 --separate-stderr bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() { echo 'mock diff'; }
+      claude() { sleep 1; echo 'should not be seen'; }
+      ( sleep 0.2; kill -INT \$\$ ) &
+      _dotfiles_commit_generate_message ''
+    "
+    assert_output ""
+  }
+  ```
+
+  Note: `claude` here is a shell function, so it runs inside the pipeline's last-stage subshell; killing that subshell (what `_dotfiles_spinner_wait` does on interrupt) does not reach its `sleep 1` grandchild, which is why the mock uses a short 1-second sleep rather than something long — any orphaned process exits on its own almost immediately. In production `claude` is a single exec'd binary with no such grandchild, so this is a test-only artifact, not a behavior gap.
+
+  Note: the `generate_message: fails when claude is not found on PATH` test is left unchanged — that path returns before any backgrounding/spinner happens, so no stderr label is emitted.
+
+- [ ] **Step 2: Run the tests to verify the new/modified ones fail**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_generate_message.bats`
+  Expected: the 2 prompt tests PASS; the PATH-missing test PASSES (unaffected); the success, non-zero, empty-output, and byte-cap tests FAIL on the new `grep -qF` stderr assertions (no spinner label is printed yet); the new interrupted test FAILS (status is `1`, not `130`, since interruption isn't implemented yet)
+
+- [ ] **Step 3: Implement the change in `_dotfiles_commit_generate_message`**
+
+  In `lib/commands.sh`, find this exact block:
+
+  ```bash
+  function _dotfiles_commit_generate_message ()
+  {
+    local ticket="$1"
+
+    if ! command -v claude > /dev/null 2>&1
+    then
+      return 1
+    fi
+
+    local raw
+    if ! raw=$(git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")")
+    then
+      return 1
+    fi
+
+    local sanitized
+    sanitized=$(_dotfiles_commit_sanitize_message "$raw")
+
+    if [ -z "$sanitized" ]
+    then
+      return 1
+    fi
+
+    printf '%s' "$sanitized"
+  }
+  ```
+
+  Replace it with:
+
+  ```bash
+  function _dotfiles_commit_generate_message ()
+  {
+    local ticket="$1"
+
+    if ! command -v claude > /dev/null 2>&1
+    then
+      return 1
+    fi
+
+    local outfile
+    outfile=$(mktemp)
+
+    git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")" > "$outfile" &
+    local pid=$!
+
+    _dotfiles_spinner_wait "$pid" "Asking Claude for a commit message..."
+    local wait_status=$?
+
+    if [ "$wait_status" -eq 130 ]
+    then
+      rm -f "$outfile"
+      return 130
+    fi
+
+    if [ "$wait_status" -ne 0 ]
+    then
+      rm -f "$outfile"
+      return 1
+    fi
+
+    local raw
+    raw=$(cat "$outfile")
+    rm -f "$outfile"
+
+    local sanitized
+    sanitized=$(_dotfiles_commit_sanitize_message "$raw")
+
+    if [ -z "$sanitized" ]
+    then
+      return 1
+    fi
+
+    printf '%s' "$sanitized"
+  }
+  ```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_generate_message.bats`
+  Expected: all 8 tests PASS
+
+- [ ] **Step 5: Run bashcheck**
+
+  Run: `bashcheck lib/commands.sh tests/commit_generate_message.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add lib/commands.sh tests/commit_generate_message.bats
+  git commit -m "feat(commit): show a spinner while generating the commit message"
+  ```
+
+---
+
+### Task 3: Propagate cancellation from `commit`
+
+**Files:**
+- Modify: `lib/commands.sh` (currently lines 115-151)
+- Modify: `tests/commit_command.bats`
+- Modify: `docs/DEVELOPMENT.md`
+
+**Interfaces:**
+- Consumes: `_dotfiles_commit_generate_message` (Task 2) — now distinguishes a `130` exit status from other failures.
+- Produces: `commit` — same public contract, plus: when generation is canceled (Ctrl-C), prints `commit canceled` to stderr and returns `130` without calling `c` or `git commit`.
+
+- [ ] **Step 1: Write the failing test**
+
+  In `tests/commit_command.bats`, append after the last `@test` block (after `commit: removes the old non-AI alias`):
+
+  ```bash
+
+  @test "commit: propagates cancellation from generate_message without falling back to c" {
+    run -130 bash -c "
+      . '$REPO_ROOT/lib/_shared.sh'
+      . '$REPO_ROOT/lib/commands.sh'
+      git() {
+        if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+        if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+        if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+        echo \"git_unexpected_call:\$*\"
+        return 0
+      }
+      _dotfiles_commit_generate_message() { return 130; }
+      c() { echo 'c_invoked'; }
+      commit
+    "
+    assert_output --partial "commit canceled"
+    refute_output --partial "c_invoked"
+    refute_output --partial "git_unexpected_call"
+  }
+  ```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_command.bats`
+  Expected: the new test FAILS — `commit` currently treats a `130` return the same as any other empty/failed generation (falls back to `c`, returns 0, not 130)
+
+- [ ] **Step 3: Implement the change in `commit`**
+
+  In `lib/commands.sh`, find this exact block:
+
+  ```bash
+  function commit ()
+  {
+    if [ -f "./.git/MERGE_HEAD" ]
+    then
+      # If committing a git merge, accept the default message
+      # shellcheck disable=SC2119 # commit() never forwards args to c
+      c
+      return
+    fi
+
+    git add -A
+
+    if git diff --cached --quiet
+    then
+      echo "nothing to commit"
+      return 0
+    fi
+
+    local ticket
+    ticket=$(git branch --show-current 2> /dev/null | _dotfiles_grep_ticket_number)
+
+    local generated
+    generated=$(_dotfiles_commit_generate_message "$ticket")
+
+    if [ -z "$generated" ]
+    then
+      echo "claude unavailable, falling back to manual commit" >&2
+      # shellcheck disable=SC2119 # commit() never forwards args to c
+      c
+      return
+    fi
+
+    local message
+    message=$(_dotfiles_commit_message "$ticket" "$generated")
+
+    git commit -m "$message" && _dotfiles_git_log_commit && _dotfiles_git_status
+  }
+  ```
+
+  Replace it with:
+
+  ```bash
+  function commit ()
+  {
+    if [ -f "./.git/MERGE_HEAD" ]
+    then
+      # If committing a git merge, accept the default message
+      # shellcheck disable=SC2119 # commit() never forwards args to c
+      c
+      return
+    fi
+
+    git add -A
+
+    if git diff --cached --quiet
+    then
+      echo "nothing to commit"
+      return 0
+    fi
+
+    local ticket
+    ticket=$(git branch --show-current 2> /dev/null | _dotfiles_grep_ticket_number)
+
+    local generated
+    generated=$(_dotfiles_commit_generate_message "$ticket")
+    local generate_status=$?
+
+    if [ "$generate_status" -eq 130 ]
+    then
+      echo "commit canceled" >&2
+      return 130
+    fi
+
+    if [ -z "$generated" ]
+    then
+      echo "claude unavailable, falling back to manual commit" >&2
+      # shellcheck disable=SC2119 # commit() never forwards args to c
+      c
+      return
+    fi
+
+    local message
+    message=$(_dotfiles_commit_message "$ticket" "$generated")
+
+    git commit -m "$message" && _dotfiles_git_log_commit && _dotfiles_git_status
+  }
+  ```
+
+- [ ] **Step 4: Run the tests to verify they all pass**
+
+  Run: `./tests/test_helper/bats-core/bin/bats tests/commit_command.bats`
+  Expected: all 7 tests PASS
+
+- [ ] **Step 5: Document the cancellation behavior**
+
+  In `docs/DEVELOPMENT.md`, find this exact line:
+
+  ```markdown
+  `commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors.
+  ```
+
+  Replace it with:
+
+  ```markdown
+  `commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors. A spinner shows progress while waiting; Ctrl-C cancels the commit (changes stay staged) instead of falling back to `c`.
+  ```
+
+- [ ] **Step 6: Run bashcheck**
+
+  Run: `bashcheck lib/commands.sh tests/commit_command.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add lib/commands.sh tests/commit_command.bats docs/DEVELOPMENT.md
+  git commit -m "feat(commit): cancel cleanly on Ctrl-C instead of falling back to c"
+  ```
+
+---
+
+### Task 4: Full suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run bashcheck across all changed files**
+
+  Run: `bashcheck lib/commands.sh tests/spinner_wait.bats tests/commit_generate_message.bats tests/commit_command.bats`
+  Expected: `All files passed`
+
+- [ ] **Step 2: Run the fast unit suite**
+
+  Run: `just test-unit`
+  Expected: all tests pass, including the 3 new `spinner_wait` tests, the updated/new `commit_generate_message` tests, and the new `commit_command` cancellation test
+
+- [ ] **Step 3: Run the full Docker suite**
+
+  Run: `just test`
+  Expected: all bats integration tests and goss infrastructure checks pass
+
+- [ ] **Step 4: Fix forward if anything fails**
+
+  If any step above fails, fix the regression in the relevant task's files, re-run the failing command until it passes, then commit the fix with a message describing what broke (e.g. `git commit -m "fix(commit): correct spinner trap cleanup on early return"`). Do not skip ahead — Task 4 is the final gate before the feature is considered done.

--- a/docs/superpowers/specs/2026-06-21-commit-progress-spinner-design.md
+++ b/docs/superpowers/specs/2026-06-21-commit-progress-spinner-design.md
@@ -1,0 +1,116 @@
+# `commit` — animated spinner while Claude generates the message
+
+**Date:** 2026-06-21
+**Status:** Approved design
+
+## Summary
+
+Add a spinner to `commit` (see `docs/superpowers/specs/2026-06-20-commit-haiku-design.md`)
+so the user gets visual feedback while `_dotfiles_commit_generate_message` waits on the
+`claude -p --model haiku` call — currently the only step with no output until it returns.
+
+## Motivation
+
+`commit` can sit silently for several seconds while the diff is sent to Claude and a
+message comes back. With no indication anything is happening, it's unclear whether the
+command is working, hung, or has crashed.
+
+## Scope
+
+The spinner wraps only the Claude generation call (`_dotfiles_commit_generate_message`).
+`git add -A` and `git commit` are local and effectively instant — they get no spinner.
+
+## Components
+
+### `_dotfiles_spinner_wait <pid> <label>` (new, `lib/commands.sh`)
+
+Watches an already-backgrounded process and shows progress while it runs.
+
+- **All output goes to stderr, never stdout.** `_dotfiles_commit_generate_message` is
+  captured via `generated=$(...)` in `commit()`; anything the spinner wrote to stdout
+  would silently corrupt the generated commit message.
+- **Interrupt handling (Ctrl-C) is unconditional**, independent of the tty check below.
+  The backgrounded pipeline runs in its own process group, so it does *not* receive the
+  terminal's SIGINT — only an explicit trap can stop it, and that has to apply
+  regardless of whether output is animated, because the orphaned-background-process risk
+  exists either way (e.g. `commit 2>/tmp/log` still runs interactively even though
+  stderr isn't a tty).
+  - `trap 'interrupted=1' INT` is installed once at the top of the function, before the
+    tty check, and explicitly cleared (`trap - INT`) before every return. The trap
+    **only sets a flag**; it never calls `return`/`exit` itself, because this function
+    runs sourced into the user's live interactive shell, where `exit` inside a trap
+    would close their terminal.
+  - A single polling loop (`while kill -0 "$pid"; do ...; sleep 0.1; done`) checks the
+    flag each cycle; when set, it breaks out, kills the backgrounded pid, and the
+    function returns `130`.
+  - Normal (non-interrupted) completion: `wait "$pid"` and return its real exit status.
+- tty detection checks **stderr**, not stdout: `[ -t 2 ]`. This only decides what gets
+  *printed* inside the same loop — it does not affect interrupt handling:
+  - **stderr is a tty:** each loop cycle redraws one frame of a 10-frame braille spinner
+    (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) at ~100ms/frame: `printf '\r%s %s' "$frame" "$label" >&2`. On
+    completion, clear the line (`printf '\r\033[K' >&2`).
+  - **stderr is not a tty** (CI, piped, log redirection): print the label once before
+    the loop starts (`printf '%s\n' "$label" >&2`), then loop silently — no escape codes
+    in logs.
+
+### `_dotfiles_commit_generate_message` (modified)
+
+Currently runs the pipeline synchronously via command substitution. Changes to:
+
+1. Background the existing pipeline, redirecting only stdout to a temp file (stderr is
+   left inherited, same as today, so real `claude` error output still surfaces on the
+   terminal unchanged):
+   ```bash
+   git diff --cached | head -c 100000 | claude -p --model haiku "$prompt" > "$outfile" &
+   pid=$!
+   ```
+2. Call `_dotfiles_spinner_wait "$pid" "Asking Claude for a commit message..."`,
+   capture its status.
+3. **Status `130`:** clean up the temp file and return `130` (propagate the cancel,
+   don't treat it as a generation failure).
+4. **Status nonzero (other failure):** clean up and return `1`, as today.
+5. **Status `0`:** read the temp file, sanitize as today, return the sanitized message
+   on stdout (or `1` if sanitizing produces an empty result, as today).
+
+### `commit` (modified)
+
+Distinguishes "user canceled" from "Claude unavailable/errored":
+
+- If `_dotfiles_commit_generate_message` returns `130`: print `commit canceled` to
+  stderr and return `130`. Do **not** fall back to `c` — the user explicitly asked to
+  stop, so don't drop them into a manual-commit editor they didn't ask for. Nothing has
+  been committed; `git add -A` already ran, so changes are simply left staged.
+- Any other empty/failed result: unchanged — print `claude unavailable, falling back to
+  manual commit` and call `c`.
+
+## Out of scope
+
+- A timeout for a hung `claude` call (not requested; existing design has none either).
+- Spinners around `git add`/`git commit` (instant, no feedback needed).
+- Preserving/restoring a pre-existing `INT` trap — interactive shells essentially never
+  have one set, and `trap - INT` (reset to default) matches that default anyway.
+
+## Testing
+
+`tests/commit_generate_message.bats` exercises the real
+`_dotfiles_commit_generate_message` (mocking `git`/`claude`), so it runs the real
+`_dotfiles_spinner_wait` too. Under bats, stderr is not a tty, so these tests exercise
+the static-label fallback path, not the animation.
+
+- bats' `run` merges stdout+stderr into `$output` by default. The new stderr label line
+  would break the existing **exact-match** assertions (e.g.
+  `assert_output "fix(bootstrap): silence brew prompt"`). Switch these tests to
+  `run --separate-stderr` so `$output` stays stdout-only (existing assertions need no
+  change) and add a `$stderr` assertion confirming the label line appears.
+- Add tests for `_dotfiles_spinner_wait` directly:
+  1. Process completes successfully → returns its exit status; label appears on stderr
+     (non-tty path).
+  2. Process exits nonzero → that status is returned.
+  3. Simulated interrupt (send the function's own trap a SIGINT, or directly set the
+     `interrupted` flag path via a fast-exiting backgrounded process plus a sent signal)
+     → returns `130`, kills the pid, no stdout output.
+- Add one case to `tests/commit_command.bats`: when
+  `_dotfiles_commit_generate_message` returns `130`, `commit` prints `commit canceled`,
+  returns `130`, and does **not** call `c` or `git commit`.
+
+Run `just test-unit` then `just test` after implementation.

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -129,9 +129,9 @@ function commit ()
 
   if [ -z "$generated" ]
   then
-    echo "claude unavailable, falling back to manual commit" >&2
-    c
-    return
+      echo "claude unavailable, falling back to manual commit" >&2
+      c "$@"
+      return
   fi
 
   local message
@@ -261,7 +261,7 @@ function ga ()
 function _dotfiles_prompt_git_branch_delete ()
 {
   echo
-  read -p "Run 'git branch -D $1'? (y/n): " confirm \
+  read -r -p "Run 'git branch -D $1'? (y/n): " confirm \
     && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] \
     || return 1
 
@@ -387,7 +387,7 @@ function wtd ()
         rm -rf "$WORKTREE_PATH" && git worktree prune || return
       else
         echo
-        read -p "Worktree has uncommitted changes. Run 'git worktree remove --force $WORKTREE_PATH'? (y/n): " confirm \
+        read -r -p "Worktree has uncommitted changes. Run 'git worktree remove --force $WORKTREE_PATH'? (y/n): " confirm \
           && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] \
           || return 1
         git worktree remove --force "$WORKTREE_PATH" || return
@@ -436,9 +436,10 @@ function histgrep ()
 
   # Pipe results from two history sources into cat
   local RESULT
+  # shellcheck disable=SC2012
   RESULT=$(cat \
     <(history | grep "$1") \
-    <(ls -d $HOME/.history/20*/* \
+    <(ls -d "$HOME"/.history/20*/* \
       | sort -r -n \
       | xargs grep -r "$1" \
       | awk -F "$AWK_REMOVE_HISTDIR" '{print $NF}') \
@@ -772,8 +773,16 @@ EOF
   IFS=$'\t' read -r _ token proj url <<<"$line"
 
   export SUPABASE_ACCESS_TOKEN="$token"
-  [[ -n "$proj" ]] && export SUPABASE_PROJECT_REF="$proj" || unset SUPABASE_PROJECT_REF
-  [[ -n "$url"  ]] && export SUPABASE_URL="$url" || unset SUPABASE_URL
+  if [[ -n "$proj" ]]; then
+    export SUPABASE_PROJECT_REF="$proj"
+  else
+    unset SUPABASE_PROJECT_REF
+  fi
+  if [[ -n "$url" ]]; then
+    export SUPABASE_URL="$url"
+  else
+    unset SUPABASE_URL
+  fi
 
   echo "Activated Supabase profile: $name  (project: ${proj:-n/a})"
 }
@@ -893,12 +902,12 @@ function tmux-small-half ()
 function useLocalIfAvailable ()
 {
   # Use local node module if available
-  if [ -f "$(which ./node_modules/.bin/${1})" ]
+  if [ -f "$(which ./node_modules/.bin/"${1}")" ]
   then
     "./node_modules/.bin/$*"
 
   # Then check for existing global install
-  elif [ -f "$(which ${1})" ]
+  elif [ -f "$(which "${1}")" ]
   then
     "$@"
 
@@ -995,7 +1004,9 @@ alias fes='f origin staging:staging'
 alias fet='f origin test:test'
 alias filetypes="git ls-files | sed 's/.*\.//' | sort | uniq -c"
 alias fix='git commit --amend -a --no-edit && _dotfiles_git_log_commit && _dotfiles_git_status'
+# shellcheck disable=SC2142
 alias gall='echo; echo; git log --oneline --all --graph --decorate  $(git reflog | awk '"'"'{print $1}'"'"')'
+# shellcheck disable=SC2142
 alias gall2='echo; echo; git log --oneline --all --graph --decorate --date=local --date=short --pretty=format:"%C(yellow)%h %C(cyan)%ad%C(auto)%d %Creset%s %C(blue)<%aN>" $(git reflog | awk '"'"'{print $1}'"'"')'
 alias gbdr='git branch -d -r'
 alias gc='gcloud compute'

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -140,11 +140,30 @@ function _dotfiles_commit_generate_message ()
     return 1
   fi
 
-  local raw
-  if ! raw=$(git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")")
+  local outfile
+  outfile=$(mktemp)
+
+  git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")" > "$outfile" &
+  local pid=$!
+
+  _dotfiles_spinner_wait "$pid" "Asking Claude for a commit message..."
+  local wait_status=$?
+
+  if [ "$wait_status" -eq 130 ]
   then
+    rm -f "$outfile"
+    return 130
+  fi
+
+  if [ "$wait_status" -ne 0 ]
+  then
+    rm -f "$outfile"
     return 1
   fi
+
+  local raw
+  raw=$(cat "$outfile")
+  rm -f "$outfile"
 
   local sanitized
   sanitized=$(_dotfiles_commit_sanitize_message "$raw")

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -68,6 +68,11 @@ function cn ()
   fi
 }
 
+function _dotfiles_commit_sanitize_message ()
+{
+  printf '%s' "$1" | head -n1 | sed -E "s/^[\"'\`[:space:]]+//; s/[\"'\`[:space:]]+$//"
+}
+
 function clean ()
 {
   if ! git clean -f -- build/ public/ vendor/; then return 1; fi

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -23,6 +23,7 @@ function aws-set-current-account-id () {
 
 # If no args are passed, open the commit editor. Otherwise commit with all
 # arguments concatenated as a string
+# shellcheck disable=SC2120 # called with args interactively; bare calls below are intentional
 function c ()
 {
   if [ -f "./.git/MERGE_HEAD" ]
@@ -113,6 +114,14 @@ function _dotfiles_commit_generate_message ()
 
 function commit ()
 {
+  if [ -f "./.git/MERGE_HEAD" ]
+  then
+    # If committing a git merge, accept the default message
+    # shellcheck disable=SC2119 # commit() never forwards args to c
+    c
+    return
+  fi
+
   git add -A
 
   if git diff --cached --quiet
@@ -129,9 +138,10 @@ function commit ()
 
   if [ -z "$generated" ]
   then
-      echo "claude unavailable, falling back to manual commit" >&2
-      c "$@"
-      return
+    echo "claude unavailable, falling back to manual commit" >&2
+    # shellcheck disable=SC2119 # commit() never forwards args to c
+    c
+    return
   fi
 
   local message

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -86,6 +86,51 @@ function _dotfiles_commit_prompt ()
   fi
 }
 
+function _dotfiles_spinner_wait ()
+{
+  local pid="$1"
+  local label="$2"
+  local interrupted=0
+  local is_tty=0
+  local frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+  local frame_index=0
+
+  trap 'interrupted=1' INT
+
+  if [ -t 2 ]
+  then
+    is_tty=1
+  else
+    printf '%s\n' "$label" >&2
+  fi
+
+  while kill -0 "$pid" 2> /dev/null
+  do
+    if [ "$interrupted" -eq 1 ]
+    then
+      kill "$pid" 2> /dev/null
+      [ "$is_tty" -eq 1 ] && printf '\r\033[K' >&2
+      trap - INT
+      return 130
+    fi
+
+    if [ "$is_tty" -eq 1 ]
+    then
+      printf '\r%s %s' "${frames[frame_index]}" "$label" >&2
+      frame_index=$(( (frame_index + 1) % 10 ))
+    fi
+
+    sleep 0.1
+  done
+
+  [ "$is_tty" -eq 1 ] && printf '\r\033[K' >&2
+
+  wait "$pid"
+  local status=$?
+  trap - INT
+  return "$status"
+}
+
 function _dotfiles_commit_generate_message ()
 {
   local ticket="$1"

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -73,6 +73,44 @@ function _dotfiles_commit_sanitize_message ()
   printf '%s' "$1" | head -n1 | sed -E "s/^[\"'\`[:space:]]+//; s/[\"'\`[:space:]]+$//"
 }
 
+function _dotfiles_commit_prompt ()
+{
+  local ticket="$1"
+
+  if [ -n "$ticket" ]
+  then
+    printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use plain imperative mood (e.g. "fix the thing"). Do not add a type or scope prefix like "feat:" or "fix(scope):" -- a ticket prefix will be added separately. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+  else
+    printf '%s' 'Write a one-line git commit message summarizing the staged diff. Use Conventional Commits style (e.g. "fix(scope): summary") when it fits, otherwise a plain imperative summary. Output a single line only, with no surrounding quotes or backticks, no Co-Authored-By line, and no other text.'
+  fi
+}
+
+function _dotfiles_commit_generate_message ()
+{
+  local ticket="$1"
+
+  if ! command -v claude > /dev/null 2>&1
+  then
+    return 1
+  fi
+
+  local raw
+  if ! raw=$(git diff --cached | head -c 100000 | claude -p --model haiku "$(_dotfiles_commit_prompt "$ticket")")
+  then
+    return 1
+  fi
+
+  local sanitized
+  sanitized=$(_dotfiles_commit_sanitize_message "$raw")
+
+  if [ -z "$sanitized" ]
+  then
+    return 1
+  fi
+
+  printf '%s' "$sanitized"
+}
+
 function clean ()
 {
   if ! git clean -f -- build/ public/ vendor/; then return 1; fi

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -111,6 +111,35 @@ function _dotfiles_commit_generate_message ()
   printf '%s' "$sanitized"
 }
 
+function commit ()
+{
+  git add -A
+
+  if git diff --cached --quiet
+  then
+    echo "nothing to commit"
+    return 0
+  fi
+
+  local ticket
+  ticket=$(git branch --show-current 2> /dev/null | _dotfiles_grep_ticket_number)
+
+  local generated
+  generated=$(_dotfiles_commit_generate_message "$ticket")
+
+  if [ -z "$generated" ]
+  then
+    echo "claude unavailable, falling back to manual commit" >&2
+    c
+    return
+  fi
+
+  local message
+  message=$(_dotfiles_commit_message "$ticket" "$generated")
+
+  git commit -m "$message" && _dotfiles_git_log_commit && _dotfiles_git_status
+}
+
 function clean ()
 {
   if ! git clean -f -- build/ public/ vendor/; then return 1; fi
@@ -943,7 +972,6 @@ alias cod='co develop'
 alias cop='co prod'
 alias com='co main'
 alias cos='co staging'
-alias commit='git commit -ev' # non-signed commit
 alias convert-crlf-lf='git ls-files -z | xargs -0 dos2unix'
 alias convert-tabs-spaces="replace '	' '  '"
 alias count='sed "/^\s*$/d" | wc -l | xargs'

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -864,7 +864,12 @@ function bashcheck ()
       errors=$((errors + 1))
       continue
     fi
-    bash -n "$file" || errors=$((errors + 1))
+    # bats' `@test "..." { ... }` syntax isn't valid raw bash, so bash -n
+    # always misfires on .bats files; shellcheck understands bats syntax
+    # natively, so skip bash -n for that extension and rely on shellcheck.
+    if [[ "$file" != *.bats ]]; then
+      bash -n "$file" || errors=$((errors + 1))
+    fi
     if [[ -n "$has_shellcheck" ]]; then
       shellcheck "$file" || errors=$((errors + 1))
     fi

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -199,6 +199,13 @@ function commit ()
 
   local generated
   generated=$(_dotfiles_commit_generate_message "$ticket")
+  local generate_status=$?
+
+  if [ "$generate_status" -eq 130 ]
+  then
+    echo "commit canceled" >&2
+    return 130
+  fi
 
   if [ -z "$generated" ]
   then

--- a/tests/bashcheck_command.bats
+++ b/tests/bashcheck_command.bats
@@ -1,0 +1,59 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+# Fixture content is built with printf rather than a heredoc containing a
+# literal "@test ... {" line, because bats-preprocess scans every physical
+# line of *this* file for that pattern and would mistake an embedded heredoc
+# line for a real test boundary, silently mangling the fixture.
+
+@test "bashcheck: does not fail a valid .bats file due to @test block syntax" {
+  local tmpdir fixture
+  tmpdir="$(mktemp -d)"
+  fixture="$tmpdir/example.bats"
+  {
+    printf 'setup() {\n'
+    printf '  :\n'
+    printf '}\n'
+    printf '\n'
+    printf '%s "example test" {\n' '@test'
+    printf '  run true\n'
+    printf '}\n'
+  } > "$fixture"
+
+  run bashcheck "$fixture"
+  assert_success
+  assert_output --partial "All files passed"
+  rm -rf "$tmpdir"
+}
+
+@test "bashcheck: still reports a real shellcheck violation in a .bats file" {
+  local tmpdir fixture
+  tmpdir="$(mktemp -d)"
+  fixture="$tmpdir/broken.bats"
+  {
+    printf '%s "example test" {\n' '@test'
+    printf "  local x=\$1\n"
+    printf "  echo \$x\n"
+    printf '}\n'
+  } > "$fixture"
+
+  run bashcheck "$fixture"
+  assert_failure
+  rm -rf "$tmpdir"
+}
+
+@test "bashcheck: still runs bash -n syntax check for non-.bats files" {
+  local tmpdir fixture
+  tmpdir="$(mktemp -d)"
+  fixture="$tmpdir/broken.sh"
+  cat > "$fixture" <<'EOF'
+function broken() {
+  echo "missing closing brace"
+EOF
+
+  run bashcheck "$fixture"
+  assert_failure
+  rm -rf "$tmpdir"
+}

--- a/tests/commit_command.bats
+++ b/tests/commit_command.bats
@@ -84,6 +84,45 @@ setup() {
   refute_output --partial "git_commit_message"
 }
 
+@test "commit: mid-merge delegates to c instead of generating an AI message" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    tmpdir=\$(mktemp -d)
+    mkdir -p \"\$tmpdir/.git\"
+    touch \"\$tmpdir/.git/MERGE_HEAD\"
+    cd \"\$tmpdir\" || exit 1
+    git() { echo \"git_unexpected_call:\$*\"; return 0; }
+    _dotfiles_commit_generate_message() { echo 'should-not-be-called'; }
+    c() { echo 'c_invoked'; }
+    commit
+    rm -rf \"\$tmpdir\"
+  "
+  assert_success
+  assert_output --partial "c_invoked"
+  refute_output --partial "should-not-be-called"
+  refute_output --partial "git_unexpected_call"
+}
+
+@test "commit: falls back to c with no forwarded args when message generation fails" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      echo \"git_commit_message:unexpected\"
+      return 0
+    }
+    _dotfiles_commit_generate_message() { return 1; }
+    c() { echo \"c_invoked_with_argc:\$#\"; }
+    commit ignored-arg
+  "
+  assert_success
+  assert_output --partial "c_invoked_with_argc:0"
+}
+
 @test "commit: removes the old non-AI alias" {
   run grep -F "alias commit=" "$REPO_ROOT/lib/commands.sh"
   assert_failure

--- a/tests/commit_command.bats
+++ b/tests/commit_command.bats
@@ -127,3 +127,23 @@ setup() {
   run grep -F "alias commit=" "$REPO_ROOT/lib/commands.sh"
   assert_failure
 }
+
+@test "commit: propagates cancellation from generate_message without falling back to c" {
+  run -130 bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      echo \"git_unexpected_call:\$*\"
+      return 0
+    }
+    _dotfiles_commit_generate_message() { return 130; }
+    c() { echo 'c_invoked'; }
+    commit
+  "
+  assert_output --partial "commit canceled"
+  refute_output --partial "c_invoked"
+  refute_output --partial "git_unexpected_call"
+}

--- a/tests/commit_command.bats
+++ b/tests/commit_command.bats
@@ -1,0 +1,90 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+@test "commit: ticket present builds TICKET: <summary> and commits" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'feature/ABC-123-b'; return 0; fi
+      if [ \"\$1\" = \"commit\" ] && [ \"\$2\" = \"-m\" ]; then echo \"git_commit_message:\$3\"; return 0; fi
+    }
+    _dotfiles_commit_generate_message() { echo 'silence brew prompt'; }
+    _dotfiles_git_log_commit() { echo 'git_log_commit'; }
+    _dotfiles_git_status() { echo 'git_status'; }
+    commit
+  "
+  assert_success
+  assert_output --partial "git_commit_message:ABC-123: silence brew prompt"
+  assert_output --partial "git_log_commit"
+  assert_output --partial "git_status"
+}
+
+@test "commit: no ticket uses the generated message verbatim" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      if [ \"\$1\" = \"commit\" ] && [ \"\$2\" = \"-m\" ]; then echo \"git_commit_message:\$3\"; return 0; fi
+    }
+    _dotfiles_commit_generate_message() { echo 'fix(bootstrap): silence brew prompt'; }
+    _dotfiles_git_log_commit() { echo 'git_log_commit'; }
+    _dotfiles_git_status() { echo 'git_status'; }
+    commit
+  "
+  assert_success
+  assert_output --partial "git_commit_message:fix(bootstrap): silence brew prompt"
+  refute_output --partial "git_commit_message:ABC"
+}
+
+@test "commit: nothing staged prints message and skips commit" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 0; fi
+      echo \"git_unexpected_call:\$*\"
+      return 0
+    }
+    _dotfiles_commit_generate_message() { echo 'should-not-be-called'; }
+    commit
+  "
+  assert_success
+  assert_output "nothing to commit"
+  refute_output --partial "should-not-be-called"
+  refute_output --partial "git_unexpected_call"
+}
+
+@test "commit: falls back to c when message generation fails" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      echo \"git_commit_message:unexpected\"
+      return 0
+    }
+    _dotfiles_commit_generate_message() { return 1; }
+    c() { echo 'c_invoked'; }
+    commit
+  "
+  assert_success
+  assert_output --partial "claude unavailable, falling back to manual commit"
+  assert_output --partial "c_invoked"
+  refute_output --partial "git_commit_message"
+}
+
+@test "commit: removes the old non-AI alias" {
+  run grep -F "alias commit=" "$REPO_ROOT/lib/commands.sh"
+  assert_failure
+}

--- a/tests/commit_generate_message.bats
+++ b/tests/commit_generate_message.bats
@@ -20,7 +20,7 @@ setup() {
 # --- _dotfiles_commit_generate_message ---
 
 @test "generate_message: returns claude's sanitized output on success" {
-  run bash -c "
+  run --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo 'mock diff'; }
@@ -29,6 +29,7 @@ setup() {
   "
   assert_success
   assert_output "fix(bootstrap): silence brew prompt"
+  echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
 }
 
 @test "generate_message: fails when claude is not found on PATH" {
@@ -46,7 +47,7 @@ setup() {
 }
 
 @test "generate_message: fails when claude exits non-zero" {
-  run bash -c "
+  run --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo 'mock diff'; }
@@ -55,10 +56,11 @@ setup() {
   "
   assert_failure
   assert_output ""
+  echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
 }
 
 @test "generate_message: fails when claude returns empty output" {
-  run bash -c "
+  run --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo ''; }
@@ -67,10 +69,11 @@ setup() {
   "
   assert_failure
   assert_output ""
+  echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
 }
 
 @test "generate_message: caps the diff sent to claude at 100000 bytes" {
-  run bash -c "
+  run --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { yes a | head -c 200000; }
@@ -79,4 +82,17 @@ setup() {
   "
   assert_success
   assert_output "100000"
+  echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+}
+
+@test "generate_message: returns 130 and emits no stdout when interrupted" {
+  run -130 --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() { echo 'mock diff'; }
+    claude() { sleep 1; echo 'should not be seen'; }
+    ( sleep 0.2; kill -INT \$\$ ) &
+    _dotfiles_commit_generate_message ''
+  "
+  assert_output ""
 }

--- a/tests/commit_generate_message.bats
+++ b/tests/commit_generate_message.bats
@@ -1,0 +1,82 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+# --- _dotfiles_commit_prompt ---
+
+@test "prompt: ticket present requests a plain summary with no Conventional Commits prefix" {
+  run _dotfiles_commit_prompt "AB-123"
+  assert_success
+  refute_output --partial "Conventional Commits"
+}
+
+@test "prompt: no ticket allows Conventional Commits style" {
+  run _dotfiles_commit_prompt ""
+  assert_success
+  assert_output --partial "Conventional Commits"
+}
+
+# --- _dotfiles_commit_generate_message ---
+
+@test "generate_message: returns claude's sanitized output on success" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() { echo 'mock diff'; }
+    claude() { echo 'fix(bootstrap): silence brew prompt'; }
+    _dotfiles_commit_generate_message ''
+  "
+  assert_success
+  assert_output "fix(bootstrap): silence brew prompt"
+}
+
+@test "generate_message: fails when claude is not found on PATH" {
+  local empty_path
+  empty_path="$(mktemp -d)"
+  run bash -c "
+    export PATH='$empty_path'
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    _dotfiles_commit_generate_message ''
+  "
+  assert_failure
+  assert_output ""
+  rm -rf "$empty_path"
+}
+
+@test "generate_message: fails when claude exits non-zero" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() { echo 'mock diff'; }
+    claude() { return 1; }
+    _dotfiles_commit_generate_message ''
+  "
+  assert_failure
+  assert_output ""
+}
+
+@test "generate_message: fails when claude returns empty output" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() { echo ''; }
+    claude() { echo ''; }
+    _dotfiles_commit_generate_message ''
+  "
+  assert_failure
+  assert_output ""
+}
+
+@test "generate_message: caps the diff sent to claude at 100000 bytes" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() { yes a | head -c 200000; }
+    claude() { wc -c | tr -d ' '; }
+    _dotfiles_commit_generate_message ''
+  "
+  assert_success
+  assert_output "100000"
+}

--- a/tests/commit_sanitize_message.bats
+++ b/tests/commit_sanitize_message.bats
@@ -19,6 +19,7 @@ setup() {
 }
 
 @test "strips surrounding backticks" {
+  # shellcheck disable=SC2016
   run _dotfiles_commit_sanitize_message '`fix the thing`'
   assert_output "fix the thing"
 }

--- a/tests/commit_sanitize_message.bats
+++ b/tests/commit_sanitize_message.bats
@@ -1,0 +1,44 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+@test "passes through a clean single-line message unchanged" {
+  run _dotfiles_commit_sanitize_message "fix the thing"
+  assert_output "fix the thing"
+}
+
+@test "strips surrounding double quotes" {
+  run _dotfiles_commit_sanitize_message '"fix the thing"'
+  assert_output "fix the thing"
+}
+
+@test "strips surrounding single quotes" {
+  run _dotfiles_commit_sanitize_message "'fix the thing'"
+  assert_output "fix the thing"
+}
+
+@test "strips surrounding backticks" {
+  run _dotfiles_commit_sanitize_message '`fix the thing`'
+  assert_output "fix the thing"
+}
+
+@test "strips leading and trailing whitespace" {
+  run _dotfiles_commit_sanitize_message "   fix the thing   "
+  assert_output "fix the thing"
+}
+
+@test "takes only the first line of multi-line output" {
+  run _dotfiles_commit_sanitize_message "$(printf 'fix the thing\nsome extra explanation\nmore text')"
+  assert_output "fix the thing"
+}
+
+@test "reduces multi-line quoted output to a clean single line" {
+  run _dotfiles_commit_sanitize_message "$(printf '"fix(bootstrap): silence brew prompt"\nThis change updates the bootstrap script.')"
+  assert_output "fix(bootstrap): silence brew prompt"
+}
+
+@test "empty input produces empty output" {
+  run _dotfiles_commit_sanitize_message ""
+  assert_output ""
+}

--- a/tests/spinner_wait.bats
+++ b/tests/spinner_wait.bats
@@ -1,0 +1,49 @@
+setup() {
+  load 'test_helper/common_setup'
+  common_setup
+}
+
+@test "spinner_wait: returns 0 when the watched process exits 0, label printed to stderr" {
+  run --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    sleep 0.2 &
+    pid=\$!
+    _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...'
+  "
+  assert_success
+  assert_output ""
+  echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+}
+
+@test "spinner_wait: returns the watched process's nonzero exit status" {
+  run -7 --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    (sleep 0.1; exit 7) &
+    pid=\$!
+    _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...'
+  "
+  assert_output ""
+}
+
+@test "spinner_wait: SIGINT kills the watched pid and returns 130 with no stdout output" {
+  run -130 --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    sleep 5 &
+    pid=\$!
+    ( sleep 0.2; kill -INT \$\$ ) &
+    _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...'
+    status=\$?
+    sleep 0.2
+    if kill -0 \"\$pid\" 2>/dev/null; then
+      echo 'pid_still_alive' >&2
+    else
+      echo 'pid_killed' >&2
+    fi
+    exit \"\$status\"
+  "
+  assert_output ""
+  echo "$stderr" | grep -qF 'pid_killed'
+}


### PR DESCRIPTION
## Summary
- Replace the `commit='git commit -ev'` alias with a `commit` shell function.
- Add `_dotfiles_commit_sanitize_message` helper to clean model output.
- Add `_dotfiles_commit_prompt` and `_dotfiles_commit_generate_message` helpers to draft one-line commit messages from staged diffs using `claude -p --model haiku`.
- `commit` stages all changes, detects ticket numbers from the branch name, builds the final message, and commits — falling back to the existing `c` function if Haiku is unavailable or errors.
- Update `docs/DEVELOPMENT.md` with the new `commit` behavior.
- Fix `bashcheck` to skip `bash -n` for `.bats` files and resolve pre-existing shellcheck issues so the gate passes.
- Install `git-delta` in the Dockerfile so the goss infrastructure check passes.

## Test Plan
- [x] `bashcheck lib/commands.sh tests/commit_sanitize_message.bats tests/commit_generate_message.bats tests/commit_command.bats tests/bashcheck_command.bats` → All files passed
- [x] `just test-unit` → 208 tests passed
- [x] `just test` → Docker suite passed (goss + integration bats)