### PR TITLE
feat: opencode default backend and agy support

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -82,7 +82,7 @@ export EDITOR='nvim'
 export REACT_EDITOR='vscode'
 
 # Commit AI backend: claude or opencode (opencode uses Kimi 2.7)
-export DOTFILES_COMMIT_BACKEND=claude
+export DOTFILES_COMMIT_BACKEND=opencode
 
 _dotfiles_debug_timing "$LINENO"
 

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -88,12 +88,12 @@ function _dotfiles_commit_prompt ()
 
 function _dotfiles_commit_backend ()
 {
-  local backend="${DOTFILES_COMMIT_BACKEND:-claude}"
+  local backend="${DOTFILES_COMMIT_BACKEND:-opencode}"
   case "$backend" in
     claude|opencode) printf '%s' "$backend" ;;
     *)
-      printf 'unknown DOTFILES_COMMIT_BACKEND=%s, using claude\n' "$backend" >&2
-      printf '%s' 'claude'
+      printf 'unknown DOTFILES_COMMIT_BACKEND=%s, using opencode\n' "$backend" >&2
+      printf '%s' 'opencode'
       ;;
   esac
 }

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -175,6 +175,11 @@ function _dotfiles_commit_generate_message ()
         | opencode run --model "$model" "$(_dotfiles_commit_prompt "$ticket")" \
           > "$outfile" 2> /dev/null &
       ;;
+    agy)
+      git diff --cached | head -c 100000 \
+        | agy --model "$model" --print "$(_dotfiles_commit_prompt "$ticket")" \
+          > "$outfile" &
+      ;;
     *)
       git diff --cached | head -c 100000 \
         | claude -p --model "$model" "$(_dotfiles_commit_prompt "$ticket")" \

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -90,7 +90,7 @@ function _dotfiles_commit_backend ()
 {
   local backend="${DOTFILES_COMMIT_BACKEND:-opencode}"
   case "$backend" in
-    claude|opencode) printf '%s' "$backend" ;;
+    claude|opencode|agy) printf '%s' "$backend" ;;
     *)
       printf 'unknown DOTFILES_COMMIT_BACKEND=%s, using opencode\n' "$backend" >&2
       printf '%s' 'opencode'
@@ -103,6 +103,7 @@ function _dotfiles_commit_model ()
   local backend="$1"
   case "$backend" in
     opencode) printf '%s' 'opencode-go/kimi-k2.7-code' ;;
+    agy)      printf '%s' 'Gemini 3.5 Flash (Low)' ;;
     *)        printf '%s' 'haiku' ;;
   esac
 }
@@ -233,14 +234,14 @@ function commit ()
         return 0
       fi
       case "$1" in
-        claude|opencode)
+        claude|opencode|agy)
           export DOTFILES_COMMIT_BACKEND="$1"
           printf 'commit backend set to %s (model: %s) for this shell\n' \
             "$1" "$(_dotfiles_commit_model "$1")"
           return 0
           ;;
         *)
-          printf 'unknown backend: %s (expected claude or opencode)\n' "$1" >&2
+          printf 'unknown backend: %s (expected claude, opencode, or agy)\n' "$1" >&2
           return 1
           ;;
       esac

--- a/tests/commit_backend.bats
+++ b/tests/commit_backend.bats
@@ -5,11 +5,11 @@ setup() {
 
 # --- _dotfiles_commit_backend ---
 
-@test "commit_backend: defaults to claude when unset" {
+@test "commit_backend: defaults to opencode when unset" {
   unset DOTFILES_COMMIT_BACKEND
   run _dotfiles_commit_backend
   assert_success
-  assert_output "claude"
+  assert_output "opencode"
 }
 
 @test "commit_backend: honors opencode" {
@@ -19,12 +19,12 @@ setup() {
   assert_output "opencode"
 }
 
-@test "commit_backend: unknown value warns to stderr and falls back to claude" {
+@test "commit_backend: unknown value warns to stderr and falls back to opencode" {
   export DOTFILES_COMMIT_BACKEND=bogus
   run --separate-stderr _dotfiles_commit_backend
   assert_success
-  assert_output "claude"
-  echo "$stderr" | grep -qF 'unknown DOTFILES_COMMIT_BACKEND=bogus'
+  assert_output "opencode"
+  echo "$stderr" | grep -qF 'unknown DOTFILES_COMMIT_BACKEND=bogus, using opencode'
 }
 
 # --- _dotfiles_commit_model ---
@@ -57,17 +57,17 @@ setup() {
   assert_output --partial "available: yes"
 }
 
-@test "commit status: defaults to claude/haiku" {
+@test "commit status: defaults to opencode/kimi 2.7" {
   run bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     unset DOTFILES_COMMIT_BACKEND
-    claude() { :; }
+    opencode() { :; }
     commit status
   "
   assert_success
-  assert_output --partial "backend:   claude"
-  assert_output --partial "model:     haiku"
+  assert_output --partial "backend:   opencode"
+  assert_output --partial "model:     opencode-go/kimi-k2.7-code"
 }
 
 # --- commit backend (setter/getter) ---
@@ -120,6 +120,6 @@ setup() {
 # --- durable default ---
 
 @test "bash_profile: exports a DOTFILES_COMMIT_BACKEND default" {
-  run grep -E "^export DOTFILES_COMMIT_BACKEND=" "$REPO_ROOT/bash_profile"
+  run grep -E "^export DOTFILES_COMMIT_BACKEND=opencode" "$REPO_ROOT/bash_profile"
   assert_success
 }

--- a/tests/commit_backend.bats
+++ b/tests/commit_backend.bats
@@ -19,6 +19,13 @@ setup() {
   assert_output "opencode"
 }
 
+@test "commit_backend: honors agy" {
+  export DOTFILES_COMMIT_BACKEND=agy
+  run _dotfiles_commit_backend
+  assert_success
+  assert_output "agy"
+}
+
 @test "commit_backend: unknown value warns to stderr and falls back to opencode" {
   export DOTFILES_COMMIT_BACKEND=bogus
   run --separate-stderr _dotfiles_commit_backend
@@ -41,6 +48,12 @@ setup() {
   assert_output "opencode-go/kimi-k2.7-code"
 }
 
+@test "commit_model: agy backend uses Gemini 3.5 Flash (Low)" {
+  run _dotfiles_commit_model agy
+  assert_success
+  assert_output "Gemini 3.5 Flash (Low)"
+}
+
 # --- commit status ---
 
 @test "commit status: reports opencode backend, model, availability" {
@@ -54,6 +67,20 @@ setup() {
   assert_success
   assert_output --partial "backend:   opencode"
   assert_output --partial "model:     opencode-go/kimi-k2.7-code"
+  assert_output --partial "available: yes"
+}
+
+@test "commit status: reports agy backend, model, availability" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    export DOTFILES_COMMIT_BACKEND=agy
+    agy() { :; }
+    commit status
+  "
+  assert_success
+  assert_output --partial "backend:   agy"
+  assert_output --partial "model:     Gemini 3.5 Flash (Low)"
   assert_output --partial "available: yes"
 }
 
@@ -83,6 +110,17 @@ setup() {
   assert_output --partial "BACKEND=opencode"
 }
 
+@test "commit backend agy: exports the backend for the current shell" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    commit backend agy > /dev/null
+    echo \"BACKEND=\$DOTFILES_COMMIT_BACKEND\"
+  "
+  assert_success
+  assert_output --partial "BACKEND=agy"
+}
+
 @test "commit backend opencode: prints a confirmation including the model" {
   run bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
@@ -108,13 +146,13 @@ setup() {
   run --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
-    export DOTFILES_COMMIT_BACKEND=claude
+    export DOTFILES_COMMIT_BACKEND=opencode
     commit backend bogus
     echo \"RC=\$? BACKEND=\$DOTFILES_COMMIT_BACKEND\"
   "
   assert_success
-  assert_output --partial "RC=1 BACKEND=claude"
-  echo "$stderr" | grep -qF 'unknown backend: bogus'
+  assert_output --partial "RC=1 BACKEND=opencode"
+  echo "$stderr" | grep -qF 'unknown backend: bogus (expected claude, opencode, or agy)'
 }
 
 # --- durable default ---

--- a/tests/commit_command.bats
+++ b/tests/commit_command.bats
@@ -65,6 +65,7 @@ setup() {
 
 @test "commit: falls back to c when message generation fails" {
   run bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() {

--- a/tests/commit_command.bats
+++ b/tests/commit_command.bats
@@ -167,3 +167,23 @@ setup() {
   assert_output --partial "opencode unavailable, falling back to manual commit"
   assert_output --partial "c_invoked"
 }
+
+@test "commit: fallback message names the active backend (agy)" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    export DOTFILES_COMMIT_BACKEND=agy
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      return 0
+    }
+    _dotfiles_commit_generate_message() { return 1; }
+    c() { echo 'c_invoked'; }
+    commit
+  "
+  assert_success
+  assert_output --partial "agy unavailable, falling back to manual commit"
+  assert_output --partial "c_invoked"
+}

--- a/tests/commit_generate_message.bats
+++ b/tests/commit_generate_message.bats
@@ -124,3 +124,31 @@ setup() {
   assert_output ""
   rm -rf "$empty_path"
 }
+
+@test "generate_message: agy backend invokes agy --print with the gemini model" {
+  run --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    export DOTFILES_COMMIT_BACKEND=agy
+    git() { echo 'mock diff'; }
+    agy() { printf '%s' \"\$2\"; }
+    _dotfiles_commit_generate_message ''
+  "
+  assert_success
+  assert_output "Gemini 3.5 Flash (Low)"
+}
+
+@test "generate_message: agy backend fails when agy is not on PATH" {
+  local empty_path
+  empty_path="$(mktemp -d)"
+  run bash -c "
+    export PATH='$empty_path'
+    export DOTFILES_COMMIT_BACKEND=agy
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    _dotfiles_commit_generate_message ''
+  "
+  assert_failure
+  assert_output ""
+  rm -rf "$empty_path"
+}

--- a/tests/commit_generate_message.bats
+++ b/tests/commit_generate_message.bats
@@ -21,6 +21,7 @@ setup() {
 
 @test "generate_message: returns claude's sanitized output on success" {
   run --separate-stderr bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo 'mock diff'; }
@@ -37,6 +38,7 @@ setup() {
   empty_path="$(mktemp -d)"
   run bash -c "
     export PATH='$empty_path'
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     _dotfiles_commit_generate_message ''
@@ -48,6 +50,7 @@ setup() {
 
 @test "generate_message: fails when claude exits non-zero" {
   run --separate-stderr bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo 'mock diff'; }
@@ -61,6 +64,7 @@ setup() {
 
 @test "generate_message: fails when claude returns empty output" {
   run --separate-stderr bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo ''; }
@@ -74,6 +78,7 @@ setup() {
 
 @test "generate_message: caps the diff sent to claude at 100000 bytes" {
   run --separate-stderr bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { yes a | head -c 200000; }
@@ -87,6 +92,7 @@ setup() {
 
 @test "generate_message: returns 130 and emits no stdout when interrupted" {
   run -130 --separate-stderr bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
     . '$REPO_ROOT/lib/_shared.sh'
     . '$REPO_ROOT/lib/commands.sh'
     git() { echo 'mock diff'; }


### PR DESCRIPTION
## Summary
- Set `opencode` as the default commit message generation backend
- Added support for the `agy` backend with model `Gemini 3.5 Flash (Low)`
- Added comprehensive bats testing for backend selection and message generation
- Fixes #136

## Test Plan
- [x] Run unit tests locally (`just test-unit tests/commit_*.bats`)
- [x] Verify commit behavior locally using `agy`