### PR TITLE
feat(commit): add DOTFILES_COMMIT_MODEL to override the default model

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -39,6 +39,7 @@ gpsu                           # git push -u origin current-branch
 ```
 
 - Commit separator configurable via `DOTFILES_COMMIT_SEPARATOR` (default: `:`)
+- Commit model override via `DOTFILES_COMMIT_MODEL` — set it to force a specific model for the active backend, overriding the per-backend default (visible in `commit status`)
 
 `commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors. A spinner shows progress while waiting; Ctrl-C cancels the commit (changes stay staged) instead of falling back to `c`.
 

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -101,6 +101,11 @@ function _dotfiles_commit_backend ()
 function _dotfiles_commit_model ()
 {
   local backend="$1"
+  if [ -n "${DOTFILES_COMMIT_MODEL:-}" ]
+  then
+    printf '%s' "$DOTFILES_COMMIT_MODEL"
+    return 0
+  fi
   case "$backend" in
     opencode) printf '%s' 'opencode-go/kimi-k2.7-code' ;;
     agy)      printf '%s' 'Gemini 3.5 Flash (Low)' ;;

--- a/tests/commit_backend.bats
+++ b/tests/commit_backend.bats
@@ -54,6 +54,27 @@ setup() {
   assert_output "Gemini 3.5 Flash (Low)"
 }
 
+@test "commit_model: DOTFILES_COMMIT_MODEL overrides the opencode default" {
+  export DOTFILES_COMMIT_MODEL="my/custom-model"
+  run _dotfiles_commit_model opencode
+  assert_success
+  assert_output "my/custom-model"
+}
+
+@test "commit_model: DOTFILES_COMMIT_MODEL overrides the claude default" {
+  export DOTFILES_COMMIT_MODEL="sonnet"
+  run _dotfiles_commit_model claude
+  assert_success
+  assert_output "sonnet"
+}
+
+@test "commit_model: empty DOTFILES_COMMIT_MODEL falls back to the backend default" {
+  export DOTFILES_COMMIT_MODEL=""
+  run _dotfiles_commit_model opencode
+  assert_success
+  assert_output "opencode-go/kimi-k2.7-code"
+}
+
 # --- commit status ---
 
 @test "commit status: reports opencode backend, model, availability" {
@@ -82,6 +103,20 @@ setup() {
   assert_output --partial "backend:   agy"
   assert_output --partial "model:     Gemini 3.5 Flash (Low)"
   assert_output --partial "available: yes"
+}
+
+@test "commit status: reflects a DOTFILES_COMMIT_MODEL override" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    export DOTFILES_COMMIT_BACKEND=opencode
+    export DOTFILES_COMMIT_MODEL='my/custom-model'
+    opencode() { :; }
+    commit status
+  "
+  assert_success
+  assert_output --partial "backend:   opencode"
+  assert_output --partial "model:     my/custom-model"
 }
 
 @test "commit status: defaults to opencode/kimi 2.7" {


### PR DESCRIPTION
Closes #143

## Summary
Adds `DOTFILES_COMMIT_MODEL` support so the commit model can be overridden without editing code. When set (non-empty), it takes precedence over the per-backend default in `_dotfiles_commit_model`; when unset or empty, behavior is unchanged (falls back to the backend default). The override is reflected everywhere the model resolves, including `commit status`.

## Changes
- `lib/commands.sh`: `_dotfiles_commit_model` honors `DOTFILES_COMMIT_MODEL` when set
- `tests/commit_backend.bats`: TDD coverage for override (opencode + claude), empty-value fallback, and `commit status` reflection
- `docs/DEVELOPMENT.md`: document the override env var

## Testing
- `just test-unit`: 245 tests, 0 failures
- `just test` (Docker): 0 failures