### PR TITLE
fix(commit): time out a hung commit backend and fall back to manual commit

### DIFF
--- a/bash_profile
+++ b/bash_profile
@@ -84,6 +84,9 @@ export REACT_EDITOR='vscode'
 # Commit AI backend: claude or opencode (opencode uses Kimi 2.7)
 export DOTFILES_COMMIT_BACKEND=opencode
 
+# Seconds to wait for the commit backend before falling back to a manual commit
+export DOTFILES_COMMIT_TIMEOUT=15
+
 _dotfiles_debug_timing "$LINENO"
 
 # Set GPG TTY and start agent

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -41,7 +41,9 @@ gpsu                           # git push -u origin current-branch
 - Commit separator configurable via `DOTFILES_COMMIT_SEPARATOR` (default: `:`)
 - Commit model override via `DOTFILES_COMMIT_MODEL` — set it to force a specific model for the active backend, overriding the per-backend default (visible in `commit status`)
 
-`commit` (no args) stages everything, asks Claude Haiku to draft the message, and commits — falling back to `c` (manual editor) if Haiku is unavailable or errors. A spinner shows progress while waiting; Ctrl-C cancels the commit (changes stay staged) instead of falling back to `c`.
+`commit` (no args) stages everything, asks the configured backend to draft the message, and commits — falling back to `c` (manual editor) if the backend is unavailable, errors, or times out. A spinner shows progress while waiting; Ctrl-C cancels the commit (changes stay staged) instead of falling back to `c`.
+
+- Commit backend timeout configurable via `DOTFILES_COMMIT_TIMEOUT` (seconds, default: `15`) — if the backend takes longer (hangs, or is stalled on a usage limit) it is killed and `commit` falls back to the manual `c` editor. Shown in `commit status`.
 
 ## Package Management
 

--- a/lib/commands.sh
+++ b/lib/commands.sh
@@ -113,14 +113,32 @@ function _dotfiles_commit_model ()
   esac
 }
 
+function _dotfiles_commit_timeout ()
+{
+  local timeout_secs="${DOTFILES_COMMIT_TIMEOUT:-15}"
+  case "$timeout_secs" in
+    ''|*[!0-9]*) timeout_secs=15 ;;
+  esac
+  printf '%s' "$timeout_secs"
+}
+
 function _dotfiles_spinner_wait ()
 {
   local pid="$1"
   local label="$2"
+  local timeout_secs="${3:-0}"
   local interrupted=0
   local is_tty=0
   local frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
   local frame_index=0
+
+  # Enable a timeout only for a positive integer; anything else means "wait forever".
+  local max_iterations=0
+  if [ "$timeout_secs" -gt 0 ] 2> /dev/null
+  then
+    max_iterations=$(( timeout_secs * 10 ))
+  fi
+  local iterations=0
 
   trap 'interrupted=1' INT
 
@@ -141,6 +159,14 @@ function _dotfiles_spinner_wait ()
       return 130
     fi
 
+    if [ "$max_iterations" -gt 0 ] && [ "$iterations" -ge "$max_iterations" ]
+    then
+      kill "$pid" 2> /dev/null
+      [ "$is_tty" -eq 1 ] && printf '\r\033[K' >&2
+      trap - INT
+      return 124
+    fi
+
     if [ "$is_tty" -eq 1 ]
     then
       printf '\r%s %s' "${frames[frame_index]}" "$label" >&2
@@ -148,6 +174,7 @@ function _dotfiles_spinner_wait ()
     fi
 
     sleep 0.1
+    iterations=$(( iterations + 1 ))
   done
 
   [ "$is_tty" -eq 1 ] && printf '\r\033[K' >&2
@@ -162,9 +189,10 @@ function _dotfiles_commit_generate_message ()
 {
   local ticket="$1"
 
-  local backend model
+  local backend model timeout_secs
   backend=$(_dotfiles_commit_backend)
   model=$(_dotfiles_commit_model "$backend")
+  timeout_secs=$(_dotfiles_commit_timeout)
 
   if ! command -v "$backend" > /dev/null 2>&1
   then
@@ -195,13 +223,19 @@ function _dotfiles_commit_generate_message ()
 
   local backend_label
   backend_label="$(printf '%s' "$backend" | head -c 1 | tr '[:lower:]' '[:upper:]')$(printf '%s' "$backend" | tail -c +2)"
-  _dotfiles_spinner_wait "$pid" "Asking ${backend_label} for a commit message..."
+  _dotfiles_spinner_wait "$pid" "Asking ${backend_label} for a commit message..." "$timeout_secs"
   local wait_status=$?
 
   if [ "$wait_status" -eq 130 ]
   then
     rm -f "$outfile"
     return 130
+  fi
+
+  if [ "$wait_status" -eq 124 ]
+  then
+    rm -f "$outfile"
+    return 124
   fi
 
   if [ "$wait_status" -ne 0 ]
@@ -229,11 +263,12 @@ function commit ()
 {
   case "$1" in
     status)
-      local b m avail=no
+      local b m t avail=no
       b=$(_dotfiles_commit_backend)
       m=$(_dotfiles_commit_model "$b")
+      t=$(_dotfiles_commit_timeout)
       command -v "$b" > /dev/null 2>&1 && avail=yes
-      printf 'backend:   %s\nmodel:     %s\navailable: %s\n' "$b" "$m" "$avail"
+      printf 'backend:   %s\nmodel:     %s\ntimeout:   %ss\navailable: %s\n' "$b" "$m" "$t" "$avail"
       return 0
       ;;
     backend)
@@ -285,6 +320,14 @@ function commit ()
   then
     echo "commit canceled" >&2
     return 130
+  fi
+
+  if [ "$generate_status" -eq 124 ]
+  then
+    echo "$(_dotfiles_commit_backend) timed out after $(_dotfiles_commit_timeout)s, falling back to manual commit" >&2
+    # shellcheck disable=SC2119 # commit() never forwards args to c
+    c
+    return
   fi
 
   if [ -z "$generated" ]

--- a/tests/commit_backend.bats
+++ b/tests/commit_backend.bats
@@ -75,6 +75,36 @@ setup() {
   assert_output "opencode-go/kimi-k2.7-code"
 }
 
+# --- _dotfiles_commit_timeout ---
+
+@test "commit_timeout: defaults to 15 when unset" {
+  unset DOTFILES_COMMIT_TIMEOUT
+  run _dotfiles_commit_timeout
+  assert_success
+  assert_output "15"
+}
+
+@test "commit_timeout: honors a numeric value" {
+  export DOTFILES_COMMIT_TIMEOUT=42
+  run _dotfiles_commit_timeout
+  assert_success
+  assert_output "42"
+}
+
+@test "commit_timeout: falls back to 15 for a non-numeric value" {
+  export DOTFILES_COMMIT_TIMEOUT=bogus
+  run _dotfiles_commit_timeout
+  assert_success
+  assert_output "15"
+}
+
+@test "commit_timeout: falls back to 15 for an empty value" {
+  export DOTFILES_COMMIT_TIMEOUT=""
+  run _dotfiles_commit_timeout
+  assert_success
+  assert_output "15"
+}
+
 # --- commit status ---
 
 @test "commit status: reports opencode backend, model, availability" {
@@ -130,6 +160,32 @@ setup() {
   assert_success
   assert_output --partial "backend:   opencode"
   assert_output --partial "model:     opencode-go/kimi-k2.7-code"
+}
+
+@test "commit status: reports the configured timeout" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    export DOTFILES_COMMIT_BACKEND=opencode
+    export DOTFILES_COMMIT_TIMEOUT=42
+    opencode() { :; }
+    commit status
+  "
+  assert_success
+  assert_output --partial "timeout:   42s"
+}
+
+@test "commit status: defaults the timeout to 15s when unset" {
+  run bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    export DOTFILES_COMMIT_BACKEND=opencode
+    unset DOTFILES_COMMIT_TIMEOUT
+    opencode() { :; }
+    commit status
+  "
+  assert_success
+  assert_output --partial "timeout:   15s"
 }
 
 # --- commit backend (setter/getter) ---
@@ -194,5 +250,10 @@ setup() {
 
 @test "bash_profile: exports a DOTFILES_COMMIT_BACKEND default" {
   run grep -E "^export DOTFILES_COMMIT_BACKEND=opencode" "$REPO_ROOT/bash_profile"
+  assert_success
+}
+
+@test "bash_profile: exports a DOTFILES_COMMIT_TIMEOUT default" {
+  run grep -E "^export DOTFILES_COMMIT_TIMEOUT=15" "$REPO_ROOT/bash_profile"
   assert_success
 }

--- a/tests/commit_command.bats
+++ b/tests/commit_command.bats
@@ -149,6 +149,50 @@ setup() {
   refute_output --partial "git_unexpected_call"
 }
 
+@test "commit: falls back to c with a timeout notice when generation times out" {
+  run bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
+    export DOTFILES_COMMIT_TIMEOUT=1
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      echo \"git_commit_message:unexpected\"
+      return 0
+    }
+    _dotfiles_commit_generate_message() { return 124; }
+    c() { echo 'c_invoked'; }
+    commit
+  "
+  assert_success
+  assert_output --partial "claude timed out after 1s, falling back to manual commit"
+  assert_output --partial "c_invoked"
+  refute_output --partial "git_commit_message"
+}
+
+@test "commit: timeout notice shows the sanitized timeout for a non-numeric value" {
+  run bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
+    export DOTFILES_COMMIT_TIMEOUT=bogus
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() {
+      if [ \"\$1\" = \"add\" ] && [ \"\$2\" = \"-A\" ]; then return 0; fi
+      if [ \"\$1\" = \"diff\" ] && [ \"\$2\" = \"--cached\" ] && [ \"\$3\" = \"--quiet\" ]; then return 1; fi
+      if [ \"\$1\" = \"branch\" ] && [ \"\$2\" = \"--show-current\" ]; then echo 'main'; return 0; fi
+      return 0
+    }
+    _dotfiles_commit_generate_message() { return 124; }
+    c() { echo 'c_invoked'; }
+    commit
+  "
+  assert_success
+  assert_output --partial "claude timed out after 15s, falling back to manual commit"
+  assert_output --partial "c_invoked"
+}
+
 @test "commit: fallback message names the active backend (opencode)" {
   run bash -c "
     . '$REPO_ROOT/lib/_shared.sh'

--- a/tests/commit_generate_message.bats
+++ b/tests/commit_generate_message.bats
@@ -103,6 +103,20 @@ setup() {
   assert_output ""
 }
 
+@test "generate_message: returns 124 and emits no stdout when the backend exceeds the timeout" {
+  run -124 --separate-stderr bash -c "
+    export DOTFILES_COMMIT_BACKEND=claude
+    export DOTFILES_COMMIT_TIMEOUT=1
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    git() { echo 'mock diff'; }
+    claude() { command sleep 10; echo 'too late'; }
+    _dotfiles_commit_generate_message ''
+  "
+  assert_output ""
+  echo "$stderr" | grep -qF 'Asking Claude for a commit message...'
+}
+
 @test "generate_message: opencode backend invokes opencode run with the kimi model" {
   run --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'

--- a/tests/spinner_wait.bats
+++ b/tests/spinner_wait.bats
@@ -27,6 +27,49 @@ setup() {
   assert_output ""
 }
 
+@test "spinner_wait: times out, kills the watched pid, and returns 124" {
+  run -124 --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    command sleep 5 &
+    pid=\$!
+    sleep() { :; }
+    _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...' 1
+    status=\$?
+    command sleep 0.2
+    if kill -0 \"\$pid\" 2>/dev/null; then
+      echo 'pid_still_alive' >&2
+    else
+      echo 'pid_killed' >&2
+    fi
+    exit \"\$status\"
+  "
+  assert_output ""
+  echo "$stderr" | grep -qF 'pid_killed'
+}
+
+@test "spinner_wait: process finishing before the timeout returns its exit status" {
+  run --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    command sleep 0.2 &
+    pid=\$!
+    _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...' 30
+  "
+  assert_success
+}
+
+@test "spinner_wait: a non-numeric timeout is treated as no timeout" {
+  run --separate-stderr bash -c "
+    . '$REPO_ROOT/lib/_shared.sh'
+    . '$REPO_ROOT/lib/commands.sh'
+    command sleep 0.2 &
+    pid=\$!
+    _dotfiles_spinner_wait \"\$pid\" 'Asking Claude for a commit message...' 'bogus'
+  "
+  assert_success
+}
+
 @test "spinner_wait: SIGINT kills the watched pid and returns 130 with no stdout output" {
   run -130 --separate-stderr bash -c "
     . '$REPO_ROOT/lib/_shared.sh'


### PR DESCRIPTION
Closes #144

## Problem
`_dotfiles_spinner_wait` loops on `while kill -0 $pid` with no time limit. If a commit backend hangs — stalled on a usage-limit prompt, a slow network, or just taking too long — the spinner spins forever and only Ctrl-C escapes. A fast non-zero exit already falls back to `c`, but a hang never did.

## Fix
- `_dotfiles_spinner_wait` gains an optional 3rd arg `timeout_secs`; when > 0 it kills the watched pid after that many seconds and returns `124` (the conventional timeout exit code). Self-contained iteration counting — no dependency on `timeout(1)`, which macOS does not ship.
- New `_dotfiles_commit_timeout` helper resolves the effective timeout from `DOTFILES_COMMIT_TIMEOUT` (default **15s**; empty or non-numeric → 15).
- `_dotfiles_commit_generate_message` passes the timeout to the spinner and returns `124` on timeout.
- `commit` maps `124` → prints `<backend> timed out after <N>s, falling back to manual commit` and drops into the manual editor (`c`) — consistent with the existing unavailable/error fallback. Changes stay staged.
- `commit status` now shows a `timeout:` line; `bash_profile` ships `DOTFILES_COMMIT_TIMEOUT=15` for discoverability.

## Testing (TDD — tests written first, watched fail, then implemented)
- `spinner_wait.bats`: times out + kills pid → 124; finishes-before-timeout returns exit status; non-numeric timeout = no timeout
- `commit_generate_message.bats`: returns 124 with no stdout when the backend exceeds the timeout
- `commit_command.bats`: timeout notice + falls back to `c`; message uses the sanitized value
- `commit_backend.bats`: `_dotfiles_commit_timeout` default/numeric/non-numeric/empty; `commit status` timeout line; `bash_profile` default
- `just test-unit`: 0 failures · `just test` (Docker): 0 failures · `bashcheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)