### PR TITLE
fix(bootstrap): install zlib dev headers before ruby source compile

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -250,6 +250,19 @@ then
       # Try precompiled ruby first (fast), fall back to source compilation
       if ! MISE_RUBY_COMPILE=0 mise install ruby 2>/dev/null; then
         echo "No precompiled ruby available for this platform, compiling from source..."
+        # ruby-build auto-detects Homebrew openssl/libyaml/gmp but NOT zlib, and
+        # passes no --with-zlib-dir. On a Linux host with only the runtime
+        # libz.so.1 (no dev headers) the zlib extension is silently skipped, so
+        # a later 'gem install' dies with "cannot load such file -- zlib
+        # (LoadError)". Install zlib dev headers first so the extension builds.
+        # (issue #149)
+        if [[ "$OSTYPE" != "darwin"* ]]; then
+          if command -v apt-get &>/dev/null; then
+            sudo apt-get install -y zlib1g-dev
+          elif command -v pacman &>/dev/null; then
+            sudo pacman -S --noconfirm --needed zlib
+          fi
+        fi
         mise install ruby
       fi
       echo

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -193,6 +193,23 @@ fi
 if   command -v curl &>/dev/null
 then
 
+  # Install OS prerequisites on Linux early — before anything compiles from
+  # source. mise's ruby source-compile fallback needs both a C toolchain
+  # (build-essential) AND zlib dev headers: ruby-build auto-detects Homebrew
+  # openssl/libyaml/gmp but NOT zlib and passes no --with-zlib-dir, so without
+  # zlib1g-dev the zlib extension is silently skipped and a later 'gem install'
+  # dies with "cannot load such file -- zlib (LoadError)" (issue #149). These
+  # are also the prerequisites brew needs before it can install.
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    if command -v apt-get &>/dev/null; then
+      sudo apt-get update
+      sudo apt-get upgrade -y
+      sudo apt-get install -y curl git build-essential zlib1g-dev xdg-utils bash-completion
+    elif command -v pacman &>/dev/null; then
+      sudo pacman -Syu --noconfirm curl git base-devel zlib bash-completion
+    fi
+  fi
+
   if   ! command -v cargo &>/dev/null
     then
       _BOOTSTRAP_INSTALL="curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
@@ -247,22 +264,11 @@ then
       mise install node go bun
       hash -r
       corepack enable
-      # Try precompiled ruby first (fast), fall back to source compilation
+      # Try precompiled ruby first (fast), fall back to source compilation.
+      # The source path needs a C toolchain + zlib dev headers, installed up
+      # front in the Linux prerequisites block above (issue #149).
       if ! MISE_RUBY_COMPILE=0 mise install ruby 2>/dev/null; then
         echo "No precompiled ruby available for this platform, compiling from source..."
-        # ruby-build auto-detects Homebrew openssl/libyaml/gmp but NOT zlib, and
-        # passes no --with-zlib-dir. On a Linux host with only the runtime
-        # libz.so.1 (no dev headers) the zlib extension is silently skipped, so
-        # a later 'gem install' dies with "cannot load such file -- zlib
-        # (LoadError)". Install zlib dev headers first so the extension builds.
-        # (issue #149)
-        if [[ "$OSTYPE" != "darwin"* ]]; then
-          if command -v apt-get &>/dev/null; then
-            sudo apt-get install -y zlib1g-dev
-          elif command -v pacman &>/dev/null; then
-            sudo pacman -S --noconfirm --needed zlib
-          fi
-        fi
         mise install ruby
       fi
       echo
@@ -281,17 +287,6 @@ then
   fi
 
   # Sourcing z.sh is obsolete
-
-  # Install brew prerequisites on Linux (needed before brew can install)
-  if [[ "$OSTYPE" != "darwin"* ]]; then
-    if command -v apt-get &>/dev/null; then
-      sudo apt-get update
-      sudo apt-get upgrade -y
-      sudo apt-get install -y curl git build-essential xdg-utils bash-completion
-    elif command -v pacman &>/dev/null; then
-      sudo pacman -Syu --noconfirm curl git base-devel bash-completion
-    fi
-  fi
 
   # Install brew if not present (macOS and Linux)
   if ! command -v brew &>/dev/null; then

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -61,6 +61,15 @@ setup() {
   [ "$status" -eq 1 ]
 }
 
+@test "bootstrap: ruby source-compile fallback installs zlib dev headers so the zlib extension builds (issue #149)" {
+  # ruby-build auto-detects Homebrew openssl/libyaml/gmp but NOT zlib, and the
+  # mise ruby source build passes no --with-zlib-dir. Without zlib dev headers
+  # the zlib extension is silently skipped and later 'gem install' fails with
+  # "cannot load such file -- zlib (LoadError)". The source-compile fallback
+  # must ensure zlib dev headers before compiling.
+  awk '/compiling from source/,/mise install ruby$/' "$REPO_ROOT/bootstrap.sh" | grep -q 'zlib1g-dev'
+}
+
 @test "bootstrap: installs gcc via brew on Linux only" {
   grep -q 'brew install gcc' "$REPO_ROOT/bootstrap.sh"
   awk '/\!\= .*darwin/{inblock=1} inblock && /brew install gcc/{found=1} inblock && /^  fi/{inblock=0} END{exit !found}' "$REPO_ROOT/bootstrap.sh"

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -61,13 +61,24 @@ setup() {
   [ "$status" -eq 1 ]
 }
 
-@test "bootstrap: ruby source-compile fallback installs zlib dev headers so the zlib extension builds (issue #149)" {
+@test "bootstrap: installs zlib dev headers in the Linux prerequisites block so ruby's source-compile fallback can build the zlib extension (issue #149)" {
   # ruby-build auto-detects Homebrew openssl/libyaml/gmp but NOT zlib, and the
   # mise ruby source build passes no --with-zlib-dir. Without zlib dev headers
   # the zlib extension is silently skipped and later 'gem install' fails with
-  # "cannot load such file -- zlib (LoadError)". The source-compile fallback
-  # must ensure zlib dev headers before compiling.
-  awk '/compiling from source/,/mise install ruby$/' "$REPO_ROOT/bootstrap.sh" | grep -q 'zlib1g-dev'
+  # "cannot load such file -- zlib (LoadError)".
+  grep -q 'apt-get install -y curl git build-essential zlib1g-dev' "$REPO_ROOT/bootstrap.sh"
+  grep -q 'base-devel zlib bash-completion' "$REPO_ROOT/bootstrap.sh"
+}
+
+@test "bootstrap: Linux prerequisites (build-essential + zlib dev headers) install before ruby source compile (issue #149)" {
+  # The prerequisites block must run BEFORE 'mise install ruby' or the headers
+  # arrive too late to help a first-run source compile.
+  local prereq_line ruby_line
+  prereq_line=$(grep -n 'build-essential zlib1g-dev' "$REPO_ROOT/bootstrap.sh" | head -1 | cut -d: -f1)
+  ruby_line=$(grep -n 'MISE_RUBY_COMPILE=0 mise install ruby' "$REPO_ROOT/bootstrap.sh" | head -1 | cut -d: -f1)
+  [ -n "$prereq_line" ]
+  [ -n "$ruby_line" ]
+  [ "$prereq_line" -lt "$ruby_line" ]
 }
 
 @test "bootstrap: installs gcc via brew on Linux only" {


### PR DESCRIPTION
## Problem

`bootstrap.sh` fails at `Installing neovim gem` with `cannot load such file -- zlib (LoadError)`.

## Root cause

When `MISE_RUBY_COMPILE=0 mise install ruby` finds no precompiled binary (e.g. a Ruby version released within the last day, as happened with 3.4.10), bootstrap falls back to compiling Ruby from source. ruby-build auto-detects Homebrew's openssl/libyaml/gmp but **not** zlib, and passes no `--with-zlib-dir`. On a Linux host with only the runtime `libz.so.1` and no `zlib1g-dev` dev headers, the zlib extension is silently skipped — so the built Ruby can't `require 'zlib'`, and every later `gem install` fails.

Confirmed by comparing `configure_args`: the working precompiled 3.4.9 has `--with-zlib-dir=...portable-zlib`; the broken source-built 3.4.10 has no zlib dir and no zlib extension.

## Fix

The Linux prerequisites block (apt/pacman) is **moved to the top** of the `curl`-guarded section — before rust, mise, and the Ruby install — and `zlib1g-dev` (apt) / `zlib` (pacman) are added alongside `build-essential`.

Placing it here (rather than in the source-compile fallback) means the C toolchain **and** zlib dev headers are guaranteed present before *any* source compile. This also fixes a latent ordering bug: the prerequisites block previously ran *after* the Ruby install, so source-compiling Ruby only worked when the host happened to already have gcc.

## Verification

- Two bats tests in `tests/bootstrap.bats` (issue #149): one asserts `zlib1g-dev`/`zlib` are in the prerequisites install lines; one asserts the prerequisites block precedes `mise install ruby` (ordering guard, since a late install wouldn't help a first-run compile).
- Full unit suite: 260 passing, 0 failures. Full Docker suite: passing.
- On the affected machine: recompiled Ruby 3.4.10 with zlib wired in → `require 'zlib'` works (zlib 3.2.3) and `gem install neovim` succeeds.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
