### PR TITLE
feat(testing): run unit tests in parallel where possible

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -27,5 +27,10 @@ jobs:
       - name: Install shellcheck
         run: brew install shellcheck
 
+      - name: Install GNU parallel
+        run: |
+          brew install parallel
+          mkdir -p ~/.parallel && touch ~/.parallel/will-cite
+
       - name: Run bash function tests
         run: just test-unit

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -59,4 +59,6 @@ jobs:
         if: always()
         run: |
           rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          if [ -d /tmp/.buildx-cache-new ]; then
+            mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          fi

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     name: Run bash function tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -24,8 +24,39 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
+      - name: Install GNU parallel
+        run: |
+          sudo apt-get update && sudo apt-get install -y parallel
+          mkdir -p ~/.parallel && touch ~/.parallel/will-cite
+
       - name: Run bash function tests
         run: just test-unit
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker image
+        run: |
+          docker buildx build \
+            --cache-from type=local,src=/tmp/.buildx-cache \
+            --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --load \
+            -t dotfiles-ci .
+
       - name: Run Docker environment tests
-        run: just test
+        run: |
+          docker compose run --rm -T ci
+
+      - name: Move cache
+        if: always()
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,55 @@ WORKDIR /dotfiles
 
 # Copy dotfiles — changes here don't bust the apt cache
 COPY . .
+
+# Symlink dotfiles configs (needed before plugin installs)
+RUN mkdir -p ~/.config/nvim ~/.config/mise \
+  && ln -sf /dotfiles/tmux/tmux-conf ~/.tmux.conf \
+  && ln -sf /dotfiles/init.vim ~/.config/nvim/init.vim \
+  && ln -sf /dotfiles/default-node-packages ~/.default-node-packages \
+  && ln -sf /dotfiles/default-gems ~/.default-gems \
+  && ln -sf /dotfiles/default-python-packages ~/.default-python-packages \
+  && ln -sf /dotfiles/mise-config.toml ~/.config/mise/config.toml
+
+# Install Go runtime + gopls via mise
+ENV GOPATH=/root/dev/go
+RUN mkdir -p "$GOPATH/bin" \
+  && mise use -g go@latest \
+  && eval "$(mise env bash)" \
+  && go install golang.org/x/tools/gopls@latest
+ENV PATH="/root/dev/go/bin:/root/.local/share/mise/shims:$PATH"
+
+# Enable corepack (yarn, pnpm)
+RUN corepack enable
+
+# Install TPM and all tmux plugins
+RUN git clone --depth 1 https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm \
+  && git clone --depth 1 https://github.com/tmux-plugins/tmux-sensible ~/.tmux/plugins/tmux-sensible \
+  && git clone --depth 1 https://github.com/tmux-plugins/tmux-resurrect ~/.tmux/plugins/tmux-resurrect \
+  && git clone --depth 1 https://github.com/thewtex/tmux-mem-cpu-load ~/.tmux/plugins/tmux-mem-cpu-load \
+  && git clone --depth 1 https://github.com/tmux-plugins/tmux-copycat ~/.tmux/plugins/tmux-copycat \
+  && git clone --depth 1 https://github.com/tmux-plugins/tmux-open ~/.tmux/plugins/tmux-open \
+  && git clone --depth 1 https://github.com/tmux-plugins/tmux-yank ~/.tmux/plugins/tmux-yank \
+  && git clone --depth 1 https://github.com/tmux-plugins/tmux-prefix-highlight ~/.tmux/plugins/tmux-prefix-highlight
+
+# Install vim-plug and Neovim plugins
+RUN curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim \
+  && nvim --headless +PlugInstall +qall 2>/dev/null
+
+# Install CoC extensions via npm
+RUN mkdir -p ~/.config/coc/extensions \
+  && cd ~/.config/coc/extensions \
+  && echo '{"dependencies":{}}' > package.json \
+  && npm install --install-strategy=shallow --ignore-scripts --no-bin-links \
+     coc-tsserver coc-pairs coc-css coc-highlight coc-json coc-git \
+     coc-snippets coc-eslint coc-emoji coc-solargraph coc-yaml coc-html \
+     coc-lists coc-svg 2>/dev/null
+
+# Install GNU parallel for bats --jobs backend
+RUN apt-get update && apt-get install -y parallel \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p ~/.parallel && touch ~/.parallel/will-cite
+
+# Mark bootstrap as complete
+RUN touch ~/.dotfiles-bootstrap-done

--- a/bash_profile
+++ b/bash_profile
@@ -50,6 +50,12 @@ unset _dotfiles_source _dotfiles_dir
 # Reset debug timing
 _dotfiles_debug_timing "$LINENO"
 
+# Commit AI backend: claude or opencode (opencode uses Kimi 2.7)
+export DOTFILES_COMMIT_BACKEND=opencode
+
+# Seconds to wait for the commit backend before falling back to a manual commit
+export DOTFILES_COMMIT_TIMEOUT=15
+
 # import api keys and local workstation-related scripts
 [ -s "$HOME/.ssh/api_keys" ] && . "$HOME/.ssh/api_keys"
 
@@ -80,12 +86,6 @@ export EDITOR='nvim'
 
 # Set React Native editor
 export REACT_EDITOR='vscode'
-
-# Commit AI backend: claude or opencode (opencode uses Kimi 2.7)
-export DOTFILES_COMMIT_BACKEND=opencode
-
-# Seconds to wait for the commit backend before falling back to a manual commit
-export DOTFILES_COMMIT_TIMEOUT=15
 
 _dotfiles_debug_timing "$LINENO"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -314,12 +314,6 @@ then
   mkdir -p "${HOMEBREW_USER_CONFIG_HOME:-$HOME/.homebrew}"
   chmod 700 "${HOMEBREW_USER_CONFIG_HOME:-$HOME/.homebrew}"
 
-  # NOTE: tmux is pinned to a --HEAD build (see the tmux guard after this list
-  # and `brew list --pinned`). tmux 3.7/3.7a broke synchronized-output
-  # (DECSET 2026) flushing over SSH, so TUIs (opencode/neovim) launch
-  # piece-by-piece / stale until a forced redraw. Fixed upstream in 3.7b, which
-  # Homebrew doesn't ship yet. `brew pin` makes this `brew install tmux` a no-op
-  # for tmux until we unpin. Tracking: https://github.com/tribou/dotfiles/issues/138
   brew install \
       bash \
       git \
@@ -357,6 +351,7 @@ then
       gh \
       glow \
       beads \
+      parallel \
       zoxide
 
   # Reinstall delta if shared libraries are mismatched (brew upgrade cleanup)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       bash -c "
         . scripts/bootstrap-test.sh &&
         goss validate --format tap &&
-        ./tests/test_helper/bats-core/bin/bats tests/integration/
+        jobs=\"$${BATS_JOBS:-$$(nproc)}\" &&
+        ./tests/test_helper/bats-core/bin/bats --jobs \"$$jobs\" tests/integration/
       "
 
   dev:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,19 +1,57 @@
-*How do we test and fix bugs? — testing requirements, test running instructions, and bug fix policies.*
+*How do we test and fix bugs? -- testing requirements, test running instructions, and bug fix policies.*
 
 # Testing
 
 ## Test Commands
 
 ```bash
-just test-unit    # Bash unit tests with bats-core (fast, no Docker)
-just test         # Full suite in Docker: goss infrastructure + bats integration tests
+just test-unit    # Bash unit tests with bats-core in parallel (fast, no Docker)
+just test         # Full suite in Docker: goss infrastructure + bats integration tests (parallel)
 just dev          # Interactive Docker dev environment
 just build        # Rebuild Docker image (after Dockerfile changes)
+just build-clean  # Rebuild Docker image from scratch, ignoring layer cache
 ```
+
+## Parallel Execution
+
+Tests run in parallel by default using bats-core `--jobs` with GNU parallel as the backend.
+
+### Default Behavior
+
+- **Linux:** Auto-detects core count via `nproc`
+- **macOS:** Auto-detects core count via `sysctl -n hw.ncpu`
+- **Fallback:** Runs with 1 job (serial) if neither command is available
+
+### Overriding Job Count
+
+Set the `BATS_JOBS` environment variable to override auto-detection:
+
+```bash
+BATS_JOBS=1 just test-unit    # Force serial execution (useful for debugging)
+BATS_JOBS=4 just test-unit    # Force 4 parallel jobs
+```
+
+### GNU parallel Dependency
+
+GNU parallel is required for bats `--jobs` to work. Install it in your environment:
+
+```bash
+# macOS
+brew install parallel
+
+# Ubuntu/Debian
+sudo apt-get install -y parallel
+
+# Silence citation notice (one-time)
+mkdir -p ~/.parallel && touch ~/.parallel/will-cite
+```
+
+In CI, GNU parallel is installed automatically in both macOS and Ubuntu workflows.
+Inside Docker, it is pre-installed in the image.
 
 ## Test Structure
 
-- **`tests/*.bats`**: Unit tests for shell functions — run fast with no Docker required
+- **`tests/*.bats`**: Unit tests for shell functions -- run fast with no Docker required
   - `commit_message.bats`, `grep_ticket_number.bats`: Core git workflow helpers
   - `fzf_lib.bats`, `npm_detection.bats`, `path.bats`: Utility function coverage
   - `agent_setup_user.bats`: Bootstrap and agent setup
@@ -43,7 +81,44 @@ The test must fail before the fix and pass after. Re-introducing the bug must ca
 
 ## Running a Specific Test
 
+When running a single test file, `--jobs` is still applied but has no observable effect since there is only one file:
+
 ```bash
 ./tests/test_helper/bats-core/bin/bats tests/<file>.bats
 ./tests/test_helper/bats-core/bin/bats tests/commit_message.bats
 ```
+
+To run a single file without parallel overhead:
+
+```bash
+BATS_JOBS=1 just test-unit tests/commit_message.bats
+```
+
+## Docker Layer Caching
+
+### Pre-baked Layers
+
+The `Dockerfile` pre-bakes expensive bootstrap steps into cached image layers:
+
+- Go + gopls (via mise)
+- Corepack (yarn, pnpm)
+- TPM + all tmux plugins
+- vim-plug + Neovim plugins
+- CoC extensions
+- GNU parallel
+
+This means `scripts/bootstrap-test.sh` is a thin shim that only activates mise, creates symlinks, and initializes bats submodules. It completes in seconds inside the Docker image.
+
+### GHA Cache Behavior
+
+The Ubuntu CI workflow uses Docker Buildx with `actions/cache` to persist Docker layers between runs:
+
+- **First run:** Builds all layers from scratch, saves cache.
+- **Subsequent runs:** Restores cached layers. Only layers affected by file changes are rebuilt.
+- **Cache key:** Based on `hashFiles('Dockerfile')`. Any Dockerfile change invalidates the cache.
+
+### When to Rebuild
+
+- **After Dockerfile structural changes:** Run `just build-clean` to rebuild without layer cache.
+- **After test-file-only changes:** Normal `just build` uses cached layers (instant rebuild).
+- **After plugin config changes:** Layers downstream of the changed config file are rebuilt automatically.

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ build-clean:
     docker compose build --no-cache
 
 # Run bash unit tests with bats-core
-test-unit *args="tests/*.bats":
+test-unit *args="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [ -n "${BATS_JOBS:-}" ]; then
@@ -31,7 +31,25 @@ test-unit *args="tests/*.bats":
     else
       jobs=1
     fi
-    ./tests/test_helper/bats-core/bin/bats --jobs "$jobs" {{args}}
+    if [ -n "{{args}}" ]; then
+      # Explicit args: run exactly what was requested
+      ./tests/test_helper/bats-core/bin/bats --jobs "$jobs" {{args}}
+    else
+      # Default: run perf tests serially first (timing-sensitive under CPU contention)
+      ./tests/test_helper/bats-core/bin/bats tests/prompt_performance.bats tests/startup_performance.bats
+      # Then run all other tests in parallel
+      shopt -s nullglob
+      other_tests=()
+      for f in tests/*.bats; do
+        case "$(basename "$f")" in
+          prompt_performance.bats|startup_performance.bats) ;;
+          *) other_tests+=("$f") ;;
+        esac
+      done
+      if [ ${#other_tests[@]} -gt 0 ]; then
+        ./tests/test_helper/bats-core/bin/bats --jobs "$jobs" "${other_tests[@]}"
+      fi
+    fi
 
 
 # Run local health checks (symlinks, tools)

--- a/justfile
+++ b/justfile
@@ -20,7 +20,18 @@ build-clean:
 
 # Run bash unit tests with bats-core
 test-unit *args="tests/*.bats":
-    ./tests/test_helper/bats-core/bin/bats {{args}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -n "${BATS_JOBS:-}" ]; then
+      jobs="$BATS_JOBS"
+    elif command -v nproc &>/dev/null; then
+      jobs="$(nproc)"
+    elif command -v sysctl &>/dev/null; then
+      jobs="$(sysctl -n hw.ncpu)"
+    else
+      jobs=1
+    fi
+    ./tests/test_helper/bats-core/bin/bats --jobs "$jobs" {{args}}
 
 
 # Run local health checks (symlinks, tools)

--- a/scripts/bootstrap-test.sh
+++ b/scripts/bootstrap-test.sh
@@ -3,38 +3,19 @@ set -eo pipefail
 
 DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export DOTFILES
-export GOPATH="$HOME/dev/go"
-mkdir -p "$GOPATH/bin"
+export GOPATH="${GOPATH:-$HOME/dev/go}"
+export PATH="$HOME/.local/bin:$HOME/dev/go/bin:$HOME/.local/share/mise/shims:$PATH"
 
-export PATH="$HOME/.local/bin:$PATH"
-MISE_BIN="$(type -P mise 2>/dev/null || true)"
-if [ -z "$MISE_BIN" ] && [ -x "$HOME/.local/bin/mise" ]
-then
-  MISE_BIN="$HOME/.local/bin/mise"
-fi
-
-if [ -z "$MISE_BIN" ]
-then
-  curl -fsSL https://mise.run | sh
-  MISE_BIN="$HOME/.local/bin/mise"
-fi
-
-eval "$("$MISE_BIN" activate bash)"
-mise use -g go@latest
-eval "$("$MISE_BIN" env bash)"
-
-GO_BIN_DIR="${GOBIN:-$GOPATH/bin}"
-if [ ! -x "$GO_BIN_DIR/gopls" ]
-then
-  go install golang.org/x/tools/gopls@latest
-fi
+# Activate mise (tools already installed in image)
+eval "$(mise activate bash)"
+eval "$(mise env bash)"
 
 # Initialize bats submodules if not already done
 if [ ! -f "$DOTFILES/tests/test_helper/bats-core/bin/bats" ]; then
   git -C "$DOTFILES" submodule update --init --recursive tests/test_helper/
 fi
 
-echo "==> Linking dotfiles configs..."
+# Idempotent symlinks (already in image, but safe for local dev outside Docker)
 mkdir -p ~/.config/nvim ~/.config/mise
 ln -sf "$DOTFILES/tmux/tmux-conf" ~/.tmux.conf
 ln -sf "$DOTFILES/init.vim" ~/.config/nvim/init.vim
@@ -43,56 +24,8 @@ ln -sf "$DOTFILES/default-gems" ~/.default-gems
 ln -sf "$DOTFILES/default-python-packages" ~/.default-python-packages
 ln -sf "$DOTFILES/mise-config.toml" ~/.config/mise/config.toml
 
-echo "==> Enabling corepack (yarn, pnpm)..."
-corepack enable
-
-echo "==> Installing TPM..."
-if [ ! -d ~/.tmux/plugins/tpm ]; then
-  git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
-fi
-
-echo "==> Installing tmux plugins..."
-# Clone plugins directly — TPM's install_plugins requires a live tmux session
-# which is unreliable in a headless CI container. Direct clones are equivalent
-# for asserting plugin presence; interactive TPM testing is via `just dev`.
-_clone_plugin() {
-  local name="$1" repo="$2"
-  local dest="$HOME/.tmux/plugins/$name"
-  if [ ! -d "$dest" ]; then
-    git clone --depth 1 "https://github.com/$repo.git" "$dest"
-  fi
-}
-_clone_plugin "tmux-sensible"        "tmux-plugins/tmux-sensible"
-_clone_plugin "tmux-resurrect"       "tmux-plugins/tmux-resurrect"
-_clone_plugin "tmux-mem-cpu-load"    "thewtex/tmux-mem-cpu-load"
-_clone_plugin "tmux-copycat"         "tmux-plugins/tmux-copycat"
-_clone_plugin "tmux-open"            "tmux-plugins/tmux-open"
-_clone_plugin "tmux-yank"            "tmux-plugins/tmux-yank"
-_clone_plugin "tmux-prefix-highlight" "tmux-plugins/tmux-prefix-highlight"
-
-echo "==> Installing vim-plug..."
-if [ ! -f ~/.local/share/nvim/site/autoload/plug.vim ]; then
-  curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-fi
-
-echo "==> Installing Neovim plugins..."
-nvim --headless +PlugInstall +qall 2>/dev/null
-
-echo "==> Installing CoC extensions..."
-# CoC installs extensions via npm into ~/.config/coc/extensions/node_modules/.
-# Running CocUpdateSync headlessly hangs because the CoC Node.js service never
-# fully initializes without a real terminal. Install directly with npm instead —
-# this is exactly what CoC does internally when you run :CocInstall.
-mkdir -p ~/.config/coc/extensions
-cd ~/.config/coc/extensions
-[ -f package.json ] || echo '{"dependencies":{}}' > package.json
-npm install --install-strategy=shallow --ignore-scripts --no-bin-links \
-  coc-tsserver coc-pairs coc-css coc-highlight coc-json coc-git \
-  coc-snippets coc-eslint coc-emoji coc-solargraph coc-yaml coc-html \
-  coc-lists coc-svg \
-  2>/dev/null
-cd - > /dev/null
+# Silence GNU parallel citation notice
+mkdir -p ~/.parallel && touch ~/.parallel/will-cite
 
 echo "==> Bootstrap complete."
 touch ~/.dotfiles-bootstrap-done

--- a/tests/test_helper/common_setup.bash
+++ b/tests/test_helper/common_setup.bash
@@ -3,6 +3,9 @@ _helper_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 load "${_helper_dir}/bats-support/load"
 load "${_helper_dir}/bats-assert/load"
 
+# Declare minimum bats version to suppress BW02 warnings in parallel mode
+bats_require_minimum_version 1.5.0
+
 # Resolve the repo root relative to this helper file
 REPO_ROOT="$(cd "${_helper_dir}/../.." && pwd)"
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @tribou :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
Enable parallel test execution via bats --jobs with GNU parallel, pre-bake Docker layers, and add GHA layer caching

Closes #139

<details>
<summary>Implementation plan</summary>

<!-- BEGIN PLAN -->
# Implementation Plan — Issue #139: Run Unit Tests in Parallel

## Summary

Enable parallel test execution via bats-core `--jobs` with GNU parallel as the backend, pre-bake expensive Docker bootstrap steps into cached image layers, and add GHA Docker layer caching. The goal is to reduce local unit test feedback from ~42s to <15s on 8-core machines, and Docker integration runtime from ~90-120s to <30s.

---

## Task 1: Add GNU parallel and `--jobs` support to justfile

**File:** `justfile`

### Interface

- `just test-unit` invokes bats with `--jobs <N>` where N is auto-detected from `nproc` (Linux) or `sysctl -n hw.ncpu` (macOS).
- `BATS_JOBS` environment variable overrides the default (e.g., `BATS_JOBS=1` for serial debugging).
- The `--no-parallelize-within-files` flag is NOT used — tests within a single file may run in parallel.

### Steps

1. RED: Add a test in `tests/bootstrap.bats` (or a new `tests/parallel_config.bats`) that asserts `just test-unit` passes with `--jobs` flag active and produces valid TAP output.
2. GREEN: Update the `test-unit` recipe in `justfile`:
   ```just
   # Run bash unit tests with bats-core
   test-unit *args="tests/*.bats":
       #!/usr/bin/env bash
       set -euo pipefail
       if [ -n "${BATS_JOBS:-}" ]; then
         jobs="$BATS_JOBS"
       elif command -v nproc &>/dev/null; then
         jobs="$(nproc)"
       elif command -v sysctl &>/dev/null; then
         jobs="$(sysctl -n hw.ncpu)"
       else
         jobs=1
       fi
       ./tests/test_helper/bats-core/bin/bats --jobs "$jobs" {{args}}
   ```
3. REFACTOR: Confirm all 30 unit test files pass under `--jobs $(nproc)`. Fix any ordering dependencies or shared-state issues if found.

### Acceptance

- `just test-unit` runs in parallel by default.
- `BATS_JOBS=1 just test-unit` runs serially.
- All 30 unit test files pass.

---

## Task 2: Install GNU parallel in CI environments

**Files:** `.github/workflows/macos-tests.yml`, `.github/workflows/ubuntu-tests.yml`

### Interface

- GNU parallel is available in `$PATH` before bats is invoked.
- The citation notice is silenced (`mkdir -p ~/.parallel && touch ~/.parallel/will-cite`).

### Steps — macOS workflow

1. RED: The workflow would fail if `parallel` is missing and `--jobs` is used with the parallel backend.
2. GREEN: Add a step after "Install shellcheck":
   ```yaml
   - name: Install GNU parallel
     run: |
       brew install parallel
       mkdir -p ~/.parallel && touch ~/.parallel/will-cite
   ```
3. REFACTOR: Ensure the step is idempotent (brew install is already idempotent).

### Steps — Ubuntu workflow

1. RED: Same as above.
2. GREEN: Add a step before "Run bash function tests":
   ```yaml
   - name: Install GNU parallel
     run: |
       sudo apt-get update && sudo apt-get install -y parallel
       mkdir -p ~/.parallel && touch ~/.parallel/will-cite
   ```
3. REFACTOR: Verify no conflicts with existing apt packages.

### Acceptance

- `which parallel` succeeds in both CI runners before tests run.
- `~/.parallel/will-cite` exists (no citation nag).

---

## Task 3: Pre-bake expensive bootstrap steps into Dockerfile layers

**File:** `Dockerfile`

### Interface

- The Docker image contains: Go + gopls (via mise), all 7 tmux plugins, vim-plug + nvim plugins, CoC extensions, and `corepack enable`.
- Each logical group is a separate `RUN` layer for optimal caching.
- `scripts/bootstrap-test.sh` is reduced to only: symlinks + bats submodule init (everything else is in the image).

### Steps

1. RED: `goss validate` assertions for Go, gopls, tmux plugins, nvim plugins, CoC extensions, and corepack must pass inside a freshly built image without running bootstrap-test.sh.
2. GREEN: Add new Dockerfile layers after `COPY . .`:

   **Layer A — Symlinks + mise config:**
   ```dockerfile
   # Symlink dotfiles configs (needed before plugin installs)
   RUN mkdir -p ~/.config/nvim ~/.config/mise \
     && ln -sf /dotfiles/tmux/tmux-conf ~/.tmux.conf \
     && ln -sf /dotfiles/init.vim ~/.config/nvim/init.vim \
     && ln -sf /dotfiles/default-node-packages ~/.default-node-packages \
     && ln -sf /dotfiles/default-gems ~/.default-gems \
     && ln -sf /dotfiles/default-python-packages ~/.default-python-packages \
     && ln -sf /dotfiles/mise-config.toml ~/.config/mise/config.toml
   ```

   **Layer B — Go + gopls via mise:**
   ```dockerfile
   # Install Go runtime + gopls via mise
   ENV GOPATH=/root/dev/go
   RUN mkdir -p "$GOPATH/bin" \
     && mise use -g go@latest \
     && eval "$(mise env bash)" \
     && go install golang.org/x/tools/gopls@latest
   ENV PATH="/root/dev/go/bin:/root/.local/share/mise/shims:$PATH"
   ```

   **Layer C — Corepack:**
   ```dockerfile
   RUN corepack enable
   ```

   **Layer D — TPM + tmux plugins:**
   ```dockerfile
   # Install TPM and all tmux plugins
   RUN git clone --depth 1 https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm \
     && git clone --depth 1 https://github.com/tmux-plugins/tmux-sensible ~/.tmux/plugins/tmux-sensible \
     && git clone --depth 1 https://github.com/tmux-plugins/tmux-resurrect ~/.tmux/plugins/tmux-resurrect \
     && git clone --depth 1 https://github.com/thewtex/tmux-mem-cpu-load ~/.tmux/plugins/tmux-mem-cpu-load \
     && git clone --depth 1 https://github.com/tmux-plugins/tmux-copycat ~/.tmux/plugins/tmux-copycat \
     && git clone --depth 1 https://github.com/tmux-plugins/tmux-open ~/.tmux/plugins/tmux-open \
     && git clone --depth 1 https://github.com/tmux-plugins/tmux-yank ~/.tmux/plugins/tmux-yank \
     && git clone --depth 1 https://github.com/tmux-plugins/tmux-prefix-highlight ~/.tmux/plugins/tmux-prefix-highlight
   ```

   **Layer E — vim-plug + Neovim plugins:**
   ```dockerfile
   # Install vim-plug and Neovim plugins
   RUN curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim \
     && nvim --headless +PlugInstall +qall 2>/dev/null
   ```

   **Layer F — CoC extensions:**
   ```dockerfile
   # Install CoC extensions via npm
   RUN mkdir -p ~/.config/coc/extensions \
     && cd ~/.config/coc/extensions \
     && echo '{"dependencies":{}}' > package.json \
     && npm install --install-strategy=shallow --ignore-scripts --no-bin-links \
        coc-tsserver coc-pairs coc-css coc-highlight coc-json coc-git \
        coc-snippets coc-eslint coc-emoji coc-solargraph coc-yaml coc-html \
        coc-lists coc-svg 2>/dev/null
   ```

   **Layer G — GNU parallel + citation silence:**
   ```dockerfile
   # Install GNU parallel for bats --jobs backend
   RUN apt-get update && apt-get install -y parallel \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p ~/.parallel && touch ~/.parallel/will-cite
   ```

   **Layer H — Bootstrap marker:**
   ```dockerfile
   RUN touch ~/.dotfiles-bootstrap-done
   ```

3. REFACTOR: Reorder layers for optimal cache invalidation — system deps first, then mise/Go (rarely changes), then plugins (occasionally change), then dotfiles COPY last if possible. Consider a two-stage COPY approach: copy only plugin config files first for plugin layers, then COPY the rest.

### Acceptance

- `docker compose build` succeeds.
- Running `goss validate` inside the built image passes without executing bootstrap-test.sh.
- Second `docker compose build` after a test-file-only change takes <5s (layer cache hit for all pre-bake layers).

---

## Task 4: Slim down `scripts/bootstrap-test.sh` to symlinks + submodule init only

**File:** `scripts/bootstrap-test.sh`

### Interface

- The script becomes a thin shim that only:
  1. Initializes bats submodules if not already present.
  2. Creates symlinks (idempotent, harmless if already done by Dockerfile).
  3. Sets up PATH/ENV for the pre-baked tools.
- All heavy installation logic is removed (moved to Dockerfile in Task 3).

### Steps

1. RED: Running `just test` with the old bootstrap inside the new pre-baked image should be functionally equivalent (all goss + bats pass).
2. GREEN: Replace `scripts/bootstrap-test.sh` with:
   ```bash
   #!/bin/bash
   set -eo pipefail

   DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
   export DOTFILES
   export GOPATH="${GOPATH:-$HOME/dev/go}"
   export PATH="$HOME/.local/bin:$HOME/dev/go/bin:$HOME/.local/share/mise/shims:$PATH"

   # Activate mise (tools already installed in image)
   eval "$(mise activate bash)"
   eval "$(mise env bash)"

   # Initialize bats submodules if not already done
   if [ ! -f "$DOTFILES/tests/test_helper/bats-core/bin/bats" ]; then
     git -C "$DOTFILES" submodule update --init --recursive tests/test_helper/
   fi

   # Idempotent symlinks (already in image, but safe for local dev outside Docker)
   mkdir -p ~/.config/nvim ~/.config/mise
   ln -sf "$DOTFILES/tmux/tmux-conf" ~/.tmux.conf
   ln -sf "$DOTFILES/init.vim" ~/.config/nvim/init.vim
   ln -sf "$DOTFILES/default-node-packages" ~/.default-node-packages
   ln -sf "$DOTFILES/default-gems" ~/.default-gems
   ln -sf "$DOTFILES/default-python-packages" ~/.default-python-packages
   ln -sf "$DOTFILES/mise-config.toml" ~/.config/mise/config.toml

   # Silence GNU parallel citation notice
   mkdir -p ~/.parallel && touch ~/.parallel/will-cite

   echo "==> Bootstrap complete."
   touch ~/.dotfiles-bootstrap-done
   ```
3. REFACTOR: Ensure `just dev` still works interactively with the slimmed bootstrap (all tools available via pre-baked image).

### Acceptance

- `scripts/bootstrap-test.sh` completes in <5s inside the Docker image.
- `just test` passes (goss + integration bats).
- `just dev` starts an interactive shell with all tools available.

---

## Task 5: Add `--jobs` to integration tests inside Docker

**File:** `docker-compose.yml`

### Interface

- The `ci` service runs bats integration tests with `--jobs` (auto-detected via nproc).
- `BATS_JOBS` env var can override.

### Steps

1. RED: Integration tests currently run serially in Docker; verify they pass first.
2. GREEN: Update `docker-compose.yml` ci command:
   ```yaml
   ci:
     extends:
       service: base
     init: true
     command: >
       bash -c "
         . scripts/bootstrap-test.sh &&
         goss validate --format tap &&
         jobs=\"${BATS_JOBS:-$(nproc)}\" &&
         ./tests/test_helper/bats-core/bin/bats --jobs \"$jobs\" tests/integration/
       "
   ```
3. REFACTOR: Verify all 3 integration test files pass in parallel. Check for tmux/nvim session conflicts between files.

### Acceptance

- `just test` runs integration tests with `--jobs`.
- All 3 integration test files pass.

---

## Task 6: Enable GHA Docker layer caching in Ubuntu CI workflow

**File:** `.github/workflows/ubuntu-tests.yml`

### Interface

- Uses `docker/setup-buildx-action` + `actions/cache` for Docker layer caching.
- Second CI run with no Dockerfile changes shows cache hit in workflow logs.

### Steps

1. RED: Currently no Docker layer caching — every CI run rebuilds all layers from scratch.
2. GREEN: Update the Ubuntu workflow:
   ```yaml
   jobs:
     test:
       name: Run bash function tests
       runs-on: ubuntu-latest
       timeout-minutes: 10

       steps:
         - name: Checkout code
           uses: actions/checkout@v6
           with:
             submodules: true

         - name: Install just
           uses: extractions/setup-just@v3

         - name: Install GNU parallel
           run: |
             sudo apt-get update && sudo apt-get install -y parallel
             mkdir -p ~/.parallel && touch ~/.parallel/will-cite

         - name: Run bash function tests
           run: just test-unit

         - name: Set up Docker Buildx
           uses: docker/setup-buildx-action@v3

         - name: Cache Docker layers
           uses: actions/cache@v4
           with:
             path: /tmp/.buildx-cache
             key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
             restore-keys: |
               ${{ runner.os }}-buildx-

         - name: Build Docker image
           run: |
             docker buildx build \
               --cache-from type=local,src=/tmp/.buildx-cache \
               --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
               --load \
               -t dotfiles-ci .

         - name: Run Docker environment tests
           run: |
             docker compose run --rm -T ci

         - name: Move cache
           if: always()
           run: |
             rm -rf /tmp/.buildx-cache
             mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   ```
3. REFACTOR: Bump `timeout-minutes` from 5 to 10 to accommodate first-run cold cache. Subsequent runs should be much faster.

### Acceptance

- First CI run builds and caches Docker layers.
- Second CI run with no Dockerfile changes shows "cache hit" in logs.
- Total CI time for cached runs is significantly reduced.

---

## Task 7: Update documentation

**File:** `docs/TESTING.md`

### Interface

- Document the new parallel test execution behavior, `BATS_JOBS` env var, GNU parallel dependency, and Docker layer caching.

### Steps

1. Update "Test Commands" section to mention parallel execution.
2. Add a "Parallel Execution" section explaining:
   - Default behavior (auto-detect cores).
   - `BATS_JOBS=1` for serial debugging.
   - GNU parallel as the required backend.
3. Update "Running a Specific Test" to mention `--jobs` is not used for single-file runs.
4. Add a "Docker Layer Caching" section explaining:
   - Pre-baked layers in Dockerfile.
   - GHA cache behavior.
   - When to run `just build-clean` (after Dockerfile structural changes).

### Acceptance

- `docs/TESTING.md` accurately reflects the new testing infrastructure.
- No stale references to the old sequential-only test execution.

---

## Task Dependency Graph

```
Task 1 (justfile --jobs) ─────────────────────┐
Task 2 (CI parallel install) ─────────────────┤
Task 3 (Dockerfile pre-bake) ──┬──────────────┤
Task 4 (slim bootstrap-test) ──┘              ├─── Task 7 (docs)
Task 5 (Docker --jobs) ───────────────────────┤
Task 6 (GHA layer caching) ───────────────────┘
```

Tasks 1 and 2 are independent of each other. Task 4 depends on Task 3. Tasks 5 and 6 depend on Tasks 3+4. Task 7 depends on all others.

---

## Global Constraints

- All changes must pass `just test-unit` and `just test`.
- No test sharding or file-splitting — rely solely on bats `--jobs`.
- No push to GHCR — cache is local to GHA runner via `actions/cache`.
- Perf log write collisions under parallel execution are accepted risk (documented in issue).
- GNU parallel must be explicitly installed in all environments (defensive, self-documenting).
- The `BATS_JOBS` environment variable MUST override the auto-detected job count in all contexts.

---

## File Structure

| File | Action |
|------|--------|
| `justfile` | Modify `test-unit` recipe to use `--jobs` |
| `.github/workflows/macos-tests.yml` | Add GNU parallel install step |
| `.github/workflows/ubuntu-tests.yml` | Add parallel install, buildx, layer caching |
| `Dockerfile` | Add pre-bake layers (Go, plugins, CoC, parallel) |
| `scripts/bootstrap-test.sh` | Slim to symlinks + submodule init + env setup |
| `docker-compose.yml` | Add `--jobs` to integration test command |
| `docs/TESTING.md` | Document parallel execution + caching |
<!-- END PLAN -->

</details>